### PR TITLE
Update storeAll to use appropriate attribute information for logging

### DIFF
--- a/tests/util/bus.test.util.js
+++ b/tests/util/bus.test.util.js
@@ -31,19 +31,19 @@ module.exports = {
 
 function storeAll(attributes, callback) {
     const busDocs = [];
-    const busNames = [];
+    const busZips = [];
     for (var i = 0; i < attributes.length; i++) {
         busDocs.push(new Bus(attributes[i]));
-        busNames.push(attributes[i].name);
+        busZips.push(attributes[i].zip);
     }
     
     Bus.collection.insertMany(busDocs).then(
         () => {
-            logger.info(`${TAG} saved Buses: ${busNames.join(",")}`);
+            logger.info(`${TAG} saved Buses: ${busZips.join(",")}`);
             callback();
         },
         (reason) => {
-            logger.error(`${TAG} could not store Buses ${busNames.join(",")}. Error: ${JSON.stringify(reason)}`);
+            logger.error(`${TAG} could not store Buses ${busZips.join(",")}. Error: ${JSON.stringify(reason)}`);
             callback(reason);
         }
     );

--- a/tests/util/defaultPermission.test.util.js
+++ b/tests/util/defaultPermission.test.util.js
@@ -8,27 +8,22 @@ const TAG = "[ DEFAULTPERMISSION.TEST.UTIL.JS ]";
 
 const DefaultPermission1 = {
     "userType": "Hacker",
-    "name": "DP1",
     "permissions": [Util.Permission.Permission1._id, Util.Permission.Permission2._id]
 };
 const DefaultPermission2 = {
     "userType": "Volunteer",
-    "name": "DP2",
     "permissions": [Util.Permission.Permission3._id, Util.Permission.Permission2._id]
 };
 const DefaultPermission3 = {
     "userType": "Staff",
-    "name": "DP3",
     "permissions": [Util.Permission.Permission5._id, Util.Permission.Permission6._id]
 };
 const DefaultPermission4 = {
     "userType": "GodStaff",
-    "name": "DP4",
     "permissions": [Util.Permission.Permission7._id, Util.Permission.Permission8._id]
 };
 const DefaultPermission5 = {
     "userType": "Sponsor",
-    "name": "DP5",
     "permissions": [Util.Permission.Permission9._id, Util.Permission.Permission10._id]
 };
 const DefaultPermissions = [
@@ -52,20 +47,20 @@ module.exports = {
 
 function storeAll(attributes, callback) {
     const permissionDocs = [];
-    const permissionNames = [];
+    const permissionTypes = [];
 
     attributes.forEach((attribute) => {
         permissionDocs.push(new DefaultPermission(attribute));
-        permissionNames.push(attribute.name);
+        permissionTypes.push(attribute.userType);
     });
 
     DefaultPermission.collection.insertMany(permissionDocs).then(
         () => {
-            logger.info(`${TAG} saved DefaultPermission: ${permissionNames.join(",")}`);
+            logger.info(`${TAG} saved DefaultPermission: ${permissionTypes.join(",")}`);
             callback();
         },
         (reason) => {
-            logger.error(`${TAG} could not store DefaultPermission ${permissionNames.join(",")}. Error: ${JSON.stringify(reason)}`);
+            logger.error(`${TAG} could not store DefaultPermission ${permissionTypes.join(",")}. Error: ${JSON.stringify(reason)}`);
             callback(reason);
         }
     );

--- a/tests/util/hacker.test.util.js
+++ b/tests/util/hacker.test.util.js
@@ -74,19 +74,19 @@ module.exports = {
 
 function storeAll(attributes, callback) {
     const hackerDocs = [];
-    const hackerNames = [];
+    const hackerIds = [];
     for (var i = 0; i < attributes.length; i++) {
         hackerDocs.push(new Hacker(attributes[i]));
-        hackerNames.push(attributes[i].name);
+        hackerIds.push(attributes[i]._id);
     }
 
     Hacker.collection.insertMany(hackerDocs).then(
         () => {
-            logger.info(`${TAG} saved Hackers: ${hackerNames.join(",")}`);
+            logger.info(`${TAG} saved Hackers: ${hackerIds.join(",")}`);
             callback();
         },
         (reason) => {
-            logger.error(`${TAG} could not store Hackers ${hackerNames.join(",")}. Error: ${JSON.stringify(reason)}`);
+            logger.error(`${TAG} could not store Hackers ${hackerIds.join(",")}. Error: ${JSON.stringify(reason)}`);
             callback(reason);
         }
     );

--- a/tests/util/sponsor.test.util.js
+++ b/tests/util/sponsor.test.util.js
@@ -2,7 +2,7 @@
 const Util = {
     Account: require("./account.test.util"),
     Hacker: require("./hacker.test.util"),
-}
+};
 const Sponsor = require("../../models/sponsor.model");
 const mongoose = require("mongoose");
 const logger = require("../../services/logger.service");
@@ -22,19 +22,19 @@ const Sponsors = [
 
 function storeAll(attributes, callback) {
     const sponsorDocs = [];
-    const sponsorNames = [];
+    const sponsorComps = [];
     attributes.forEach((attribute) => {
         sponsorDocs.push(new Sponsor(attribute));
-        sponsorNames.push(attribute.name);
+        sponsorComps.push(attribute.company);
     });
 
     Sponsor.collection.insertMany(sponsorDocs).then(
         () => {
-            logger.info(`${TAG} saved Sponsors: ${sponsorNames.join(",")}`);
+            logger.info(`${TAG} saved Sponsors: ${sponsorComps.join(",")}`);
             callback();
         },
         (reason) => {
-            logger.error(`${TAG} could not store Sponsors ${sponsorNames.join(",")}. Error: ${JSON.stringify(reason)}`);
+            logger.error(`${TAG} could not store Sponsors ${sponsorComps.join(",")}. Error: ${JSON.stringify(reason)}`);
             callback(reason);
         }
     );

--- a/tests/util/staff.test.util.js
+++ b/tests/util/staff.test.util.js
@@ -18,19 +18,19 @@ const Staffs = [
 
 function storeAll(attributes, callback) {
     const staffDocs = [];
-    const staffNames = [];
+    const staffIds = [];
     attributes.forEach((attribute) => {
         staffDocs.push(new Staff(attribute));
-        staffNames.push(attribute.name);
+        staffIds.push(attribute._id);
     });
 
     Staff.collection.insertMany(staffDocs).then(
         () => {
-            logger.info(`${TAG} saved Staffs: ${staffNames.join(",")}`);
+            logger.info(`${TAG} saved Staffs: ${staffIds.join(",")}`);
             callback();
         },
         (reason) => {
-            logger.error(`${TAG} could not store Staffs ${staffNames.join(",")}. Error: ${JSON.stringify(reason)}`);
+            logger.error(`${TAG} could not store Staffs ${staffIds.join(",")}. Error: ${JSON.stringify(reason)}`);
             callback(reason);
         }
     );

--- a/tests/util/volunteer.test.util.js
+++ b/tests/util/volunteer.test.util.js
@@ -17,19 +17,19 @@ const Volunteers = [
 
 function storeAll (attributes, callback) {
     const volunteerDocs = [];
-    const volunteerNames = [];
+    const volunteerIds = [];
     attributes.forEach((attribute) => {
         volunteerDocs.push(new Volunteer(attribute));
-        volunteerNames.push(attribute.name);
+        volunteerIds.push(attribute._id);
     });
 
     Volunteer.collection.insertMany(volunteerDocs).then(
         () => {
-            logger.info(`${TAG} saved Team: ${volunteerNames.join(",")}`);
+            logger.info(`${TAG} saved Team: ${volunteerIds.join(",")}`);
             callback();
         },
         (reason) => {
-            logger.error(`${TAG} could not store Team ${volunteerNames.join(",")}. Error: ${JSON.stringify(reason)}`);
+            logger.error(`${TAG} could not store Team ${volunteerIds.join(",")}. Error: ${JSON.stringify(reason)}`);
             callback(reason);
         }
     );


### PR DESCRIPTION
Changed for all utils except for account, which is changed in feature/gcp-storage and those already with .name attributes in the schema