### PR TITLE
Add custom error handler to login

### DIFF
--- a/constants/error.constant.js
+++ b/constants/error.constant.js
@@ -30,6 +30,7 @@ const TEAM_CREATE_500_MESSAGE = "Error while creating team";
 const VOLUNTEER_CREATE_500_MESSAGE = "Error while creating volunteer";
 const EMAIL_500_MESSAGE = "Error while generating email";
 const GENERIC_500_MESSAGE = "Internal error";
+const LOGIN_500_MESSAGE = "Error while logging in";
 
 module.exports = {
     ACCOUNT_404_MESSAGE: ACCOUNT_404_MESSAGE,
@@ -57,4 +58,5 @@ module.exports = {
     EMAIL_500_MESSAGE: EMAIL_500_MESSAGE,
     GENERIC_500_MESSAGE: GENERIC_500_MESSAGE,
     ACCOUNT_DUPLICATE_422_MESSAGE: ACCOUNT_DUPLICATE_422_MESSAGE,
+    LOGIN_500_MESSAGE: LOGIN_500_MESSAGE,
 };

--- a/docs/api/api_data.js
+++ b/docs/api/api_data.js
@@ -1,1 +1,1770 @@
-define({ "api": [  {    "type": "post",    "url": "/account/",    "title": "create a new account",    "name": "create",    "group": "Account",    "version": "0.0.8",    "parameter": {      "fields": {        "body": [          {            "group": "body",            "type": "String",            "optional": false,            "field": "firstName",            "description": "<p>First name of the account creator.</p>"          },          {            "group": "body",            "type": "String",            "optional": false,            "field": "lastName",            "description": "<p>Last name of the account creator.</p>"          },          {            "group": "body",            "type": "String",            "optional": false,            "field": "email",            "description": "<p>Email of the account.</p>"          },          {            "group": "body",            "type": "String",            "optional": false,            "field": "dietaryRestrictions",            "description": "<p>Any dietary restrictions for the user. 'None' if there are no restrictions</p>"          },          {            "group": "body",            "type": "String",            "optional": false,            "field": "shirtSize",            "description": "<p>Size of the shirt that the user will receive.</p>"          },          {            "group": "body",            "type": "String",            "optional": false,            "field": "passowrd",            "description": "<p>The password of the account.</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>Account object</p>"          }        ]      },      "examples": [        {          "title": "Success-Response: ",          "content": "{\n               \"message\": \"Account creation successful\", \n               \"data\": {...}\n           }",          "type": "object"        }      ]    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Error message</p>"          },          {            "group": "Error 4xx",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Error-Response: ",          "content": "{\"message\": \"Account already exists\", \"data\": {}}",          "type": "object"        }      ]    },    "filename": "routes/api/account.js",    "groupTitle": "Account",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/account/"      }    ]  },  {    "type": "get",    "url": "/account/:id",    "title": "gets information from an account with mongoid ':id'",    "name": "getAccount",    "group": "Account",    "version": "0.0.8",    "parameter": {      "fields": {        "param": [          {            "group": "param",            "type": "ObjectId",            "optional": false,            "field": "id",            "description": "<p>MongoId of an account</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>Account object</p>"          }        ]      },      "examples": [        {          "title": "Success-Response: ",          "content": "{\n               \"message\": \"Account found by user id\", \n               \"data\": {AccountObject}\n           }",          "type": "object"        }      ]    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Error message</p>"          },          {            "group": "Error 4xx",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Error-Response: ",          "content": "{\"message\": \"Account not found\", \"data\": {}}",          "type": "object"        }      ]    },    "filename": "routes/api/account.js",    "groupTitle": "Account",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/account/:id"      }    ]  },  {    "type": "get",    "url": "/account/self",    "title": "get information about own account",    "name": "self",    "group": "Account",    "version": "0.0.8",    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>Account object</p>"          }        ]      },      "examples": [        {          "title": "Success-Response: ",          "content": "{\n               \"message\": \"Account found by user email\", \n               \"data\": {AccountObject}\n           }",          "type": "object"        }      ]    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Error message</p>"          },          {            "group": "Error 4xx",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Error-Response: ",          "content": "{\"message\": \"Account not found\", \"data\": {}}",          "type": "object"        }      ]    },    "filename": "routes/api/account.js",    "groupTitle": "Account",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/account/self"      }    ]  },  {    "type": "patch",    "url": "/account/:id",    "title": "update an account's information",    "name": "updateOneUser",    "group": "Account",    "version": "0.0.8",    "parameter": {      "fields": {        "body": [          {            "group": "body",            "type": "String",            "optional": true,            "field": "firstName",            "description": "<p>First name of the account creator.</p>"          },          {            "group": "body",            "type": "String",            "optional": true,            "field": "lastName",            "description": "<p>Last name of the account creator.</p>"          },          {            "group": "body",            "type": "String",            "optional": true,            "field": "email",            "description": "<p>Email of the account.</p>"          },          {            "group": "body",            "type": "String",            "optional": true,            "field": "dietaryRestrictions",            "description": "<p>Any dietary restrictions for the user. 'None' if there are no restrictions</p>"          },          {            "group": "body",            "type": "String",            "optional": true,            "field": "shirtSize",            "description": "<p>Size of the shirt that the user will receive.</p>"          },          {            "group": "body",            "type": "String",            "optional": true,            "field": "passowrd",            "description": "<p>The password of the account.</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>Account object</p>"          }        ]      },      "examples": [        {          "title": "Success-Response: ",          "content": "{\n               \"message\": \"Changed account information\", \n               \"data\": {...}\n           }",          "type": "object"        }      ]    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Error message</p>"          },          {            "group": "Error 4xx",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Error-Response: ",          "content": "{\"message\": \"Error while updating account\", \"data\": {}}",          "type": "object"        }      ]    },    "filename": "routes/api/account.js",    "groupTitle": "Account",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/account/:id"      }    ]  },  {    "type": "post",    "url": "/auth/confirm/:token",    "title": "confirm account using the JWT in :token",    "name": "confirmAccount",    "group": "Authentication",    "version": "0.0.8",    "parameter": {      "fields": {        "Parameter": [          {            "group": "Parameter",            "type": "String",            "optional": false,            "field": "JWT",            "description": "<p>for confirming the account</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Success-Response:",          "content": "{\"message\": \"Successfully confirmed account\", \"data\": {}}",          "type": "json"        }      ]    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Error message</p>"          },          {            "group": "Error 4xx",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Error-Response: ",          "content": "{\"message\": \"Invalid token for confirming account, \"data\": {}}",          "type": "object"        }      ]    },    "filename": "routes/api/auth.js",    "groupTitle": "Authentication",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/auth/confirm/:token"      }    ]  },  {    "type": "post",    "url": "/auth/password/forgot",    "title": "forgot password route",    "name": "forgotPassword",    "group": "Authentication",    "version": "0.0.8",    "parameter": {      "fields": {        "Parameter": [          {            "group": "Parameter",            "type": "String",            "optional": false,            "field": "email",            "description": "<p>the email address of the account</p>"          }        ]      },      "examples": [        {          "title": "Request-Example:",          "content": "{ \"email\": \"myemail@mchacks.ca\" }",          "type": "json"        }      ]    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Success-Response: ",          "content": "{\"message\": \"Sent reset email\", \"data\": {}}",          "type": "json"        }      ]    },    "permission": [      {        "name": ": public"      }    ],    "filename": "routes/api/auth.js",    "groupTitle": "Authentication",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/auth/password/forgot"      }    ]  },  {    "type": "post",    "url": "/auth/login",    "title": "login to the service",    "name": "login",    "group": "Authentication",    "version": "0.0.8",    "parameter": {      "fields": {        "Parameter": [          {            "group": "Parameter",            "type": "string",            "optional": false,            "field": "email",            "description": "<p>Account email</p>"          },          {            "group": "Parameter",            "type": "string",            "optional": false,            "field": "password",            "description": "<p>Account password</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Success-Response: ",          "content": "{\"message\": \"Successfully logged in\", \"data\": {}}",          "type": "object"        }      ]    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Error message</p>"          },          {            "group": "Error 4xx",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Error-Response: ",          "content": "{\"message\": \"Invalid email or password\", \"data\": {}}",          "type": "object"        }      ]    },    "permission": [      {        "name": ": public"      }    ],    "filename": "routes/api/auth.js",    "groupTitle": "Authentication",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/auth/login"      }    ]  },  {    "type": "get",    "url": "/auth/logout",    "title": "logout of service",    "name": "logout",    "group": "Authentication",    "version": "0.0.8",    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Success-Response: ",          "content": "{\"message\": \"Successfully logged out\", \"data\": {}}",          "type": "object"        }      ]    },    "permission": [      {        "name": ": public"      }    ],    "filename": "routes/api/auth.js",    "groupTitle": "Authentication",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/auth/logout"      }    ]  },  {    "type": "get",    "url": "/auth/confirm/resend",    "title": "resend confirmation token",    "name": "resendConfirmAccount",    "group": "Authentication",    "version": "0.0.8",    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Success-Response:",          "content": "{\"message\": \"Successfully resent confirmation email\", \"data\": {}}",          "type": "json"        }      ]    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Error message</p>"          },          {            "group": "Error 4xx",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Error-Response:",          "content": " HTTP/1.1 422\n{\"message\": \"Account already confirmed, \"data\": {}}",          "type": "json"        },        {          "title": "Error-Response:",          "content": " HTTP/1.1 428\n{\"message\": \"Account already confirmed, \"data\": {}}",          "type": "json"        }      ]    },    "filename": "routes/api/auth.js",    "groupTitle": "Authentication",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/auth/confirm/resend"      }    ]  },  {    "type": "post",    "url": "/auth/password/reset",    "title": "reset password",    "name": "resetPassword",    "group": "Authentication",    "version": "0.0.8",    "parameter": {      "fields": {        "Parameter": [          {            "group": "Parameter",            "type": "String",            "optional": false,            "field": "password",            "description": "<p>the password of the account</p>"          }        ]      },      "examples": [        {          "title": "Request-Example:",          "content": "{ \"password\": \"hunter2\" }",          "type": "json"        }      ]    },    "header": {      "fields": {        "Header": [          {            "group": "Header",            "type": "String",            "optional": false,            "field": "Authentication",            "description": "<p>the token that was provided in the reset password email</p>"          }        ]      },      "examples": [        {          "title": "Header-Example:",          "content": "{\n  \"X-Reset-Token\": \"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c\"\n}",          "type": "json"        }      ]    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Success-Response: ",          "content": "{\"message\": \"Successfully reset password\", \"data\": {}}",          "type": "json"        }      ]    },    "permission": [      {        "name": ": must have authentication token"      }    ],    "filename": "routes/api/auth.js",    "groupTitle": "Authentication",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/auth/password/reset"      }    ]  },  {    "type": "get",    "url": "/auth/rolebindings/:id",    "title": "retrieve rolebindings for a user given by their user id :id",    "name": "getRoleBindings",    "group": "Auth",    "version": "0.0.8",    "parameter": {      "fields": {        "param": [          {            "group": "param",            "type": "ObjectId",            "optional": false,            "field": "id",            "description": "<p>MongoId of an account</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>Rolebindings object</p>"          }        ]      },      "examples": [        {          "title": "Success-Response: ",          "content": "{\n               \"message\": \"Successfully retrieved role bindings\",\n               \"data\": {\n                   accountId:\"5beca4ab2e069a34f91697b2\"\n                   id:\"5beca4ae2e069a34f91698b1\"\n                   roles: [\n                       {\n                           _id:\"5beca4ab2e069a34f91697d9\",\n                           name:\"hacker\",\n                           routes: [\n                               0:Object {_id: \"5beca4ae2e069a34f9169852\", requestType: \"POST\", uri: \"/api/auth/login\"},\n                               1:Object {_id: \"5beca4ae2e069a34f9169851\", requestType: \"POST\", uri: \"/api/auth/logout\"},\n                               2:Object {_id: \"5beca4ae2e069a34f9169850\", requestType: \"GET\", uri: \"/api/auth/rolebindings/:self\"},\n                               3:Object {_id: \"5beca4ae2e069a34f916984f\", requestType: \"GET\", uri: \"/api/account/self\"},\n                               4:Object {_id: \"5beca4ae2e069a34f916984e\", requestType: \"GET\", uri: \"/api/account/:self\"},\n                               5:Object {_id: \"5beca4ae2e069a34f916984d\", requestType: \"PATCH\", uri: \"/api/account/:self\"},\n                               6:Object {_id: \"5beca4ae2e069a34f916984c\", requestType: \"POST\", uri: \"/api/hacker/\"},\n                               7:Object {_id: \"5beca4ae2e069a34f916984b\", requestType: \"GET\", uri: \"/api/hacker/:self\"},\n                               8:Object {_id: \"5beca4ae2e069a34f916984a\", requestType: \"GET\", uri: \"/api/hacker/:self/resume\"},\n                               9:Object {_id: \"5beca4ae2e069a34f9169849\", requestType: \"PATCH\", uri: \"/api/hacker/:self\"}\n                           ]\n                       }\n                   ]\n               }\n           }",          "type": "object"        }      ]    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Error message</p>"          },          {            "group": "Error 4xx",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Error-Response: ",          "content": "{\"message\": \"Role Bindings not found\", \"data\": {}}",          "type": "object"        }      ]    },    "filename": "routes/api/auth.js",    "groupTitle": "Auth",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/auth/rolebindings/:id"      }    ]  },  {    "type": "post",    "url": "/hacker/",    "title": "create a new hacker",    "name": "createHacker",    "group": "Hacker",    "version": "0.0.8",    "parameter": {      "fields": {        "body": [          {            "group": "body",            "type": "MongoID",            "optional": false,            "field": "accountId",            "description": "<p>ObjectID of the respective account</p>"          },          {            "group": "body",            "type": "String",            "optional": false,            "field": "school",            "description": "<p>Name of the school the hacker goes to</p>"          },          {            "group": "body",            "type": "String",            "optional": false,            "field": "gender",            "description": "<p>Gender of the hacker</p>"          },          {            "group": "body",            "type": "Boolean",            "optional": false,            "field": "needsBus",            "description": "<p>Whether the hacker requires a bus for transportation</p>"          },          {            "group": "body",            "type": "Json",            "optional": false,            "field": "application",            "description": "<p>The hacker's application. Resume and jobInterest fields are required.</p>"          }        ]      },      "examples": [        {          "title": "application: ",          "content": "{\n    \"portfolioURL\": {\n        \"resume\": \"...\"\n        \"github\": \"...\",\n        \"dropler\": \"...\",\n        \"personal\": \"...\",\n        \"linkedIn\": \"...\",\n        \"other\": \"...\"\n    },\n    \"jobInterest\": \"...\",\n    \"skills\": [\"CSS\", \"HTML\"],    \n    \"comments\": \"...\",\n    \"essay\": \"...\",\n    \"team\": [id1, id2],\n}",          "type": "Json"        }      ]    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>Hacker object</p>"          }        ]      },      "examples": [        {          "title": "Success-Response: ",          "content": "{\n    \"message\": \"Hacker creation successful\", \n    \"data\": {...}\n}",          "type": "object"        }      ]    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Error message</p>"          },          {            "group": "Error 4xx",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Error-Response: ",          "content": "{\"message\": \"Error while creating hacker\", \"data\": {}}",          "type": "object"        }      ]    },    "filename": "routes/api/hacker.js",    "groupTitle": "Hacker",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/hacker/"      }    ]  },  {    "type": "get",    "url": "/hacker/:id",    "title": "get a hacker's information",    "name": "getHacker",    "group": "Hacker",    "version": "0.0.8",    "parameter": {      "fields": {        "param": [          {            "group": "param",            "type": "String",            "optional": false,            "field": "id",            "description": "<p>a hacker's unique mongoID</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "String",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "Object",            "optional": false,            "field": "data",            "description": "<p>Sponsor object</p>"          }        ]      },      "examples": [        {          "title": "Success-Response: ",          "content": "{\n               \"message\": \"Successfully retrieved hacker information\", \n               \"data\": {...}\n           }",          "type": "object"        }      ]    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "type": "String",            "optional": false,            "field": "message",            "description": "<p>Error message</p>"          },          {            "group": "Error 4xx",            "type": "Object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Error-Response: ",          "content": "{\"message\": \"Hacker not found\", \"data\": {}}",          "type": "object"        }      ]    },    "filename": "routes/api/hacker.js",    "groupTitle": "Hacker",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/hacker/:id"      }    ]  },  {    "type": "get",    "url": "/hacker/resume:id",    "title": "get the resume for a hacker.",    "name": "getHackerResume",    "group": "Hacker",    "version": "0.0.8",    "parameter": {      "fields": {        "param": [          {            "group": "param",            "type": "ObjectId",            "optional": false,            "field": "id",            "description": "<p>Hacker id</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "String",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          }        ]      },      "examples": [        {          "title": "Success-Response:",          "content": "HTTP/1.1 200 OK \n{ \n    message: \"Downloaded resume\", \n    data: { \n        id: \"507f191e810c19729de860ea\", \n        resume: [Buffer] \n    } \n}",          "type": "json"        }      ]    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "type": "String",            "optional": false,            "field": "message",            "description": "<p>&quot;Resume does not exist&quot;</p>"          }        ]      },      "examples": [        {          "title": "Error-Response:",          "content": "HTTP/1.1 404 \n{ \n    message: \"Resume not found\", \n    data: {} \n}",          "type": "json"        }      ]    },    "permission": [      {        "name": "Must be logged in, and the account id must be linked to the hacker."      }    ],    "filename": "routes/api/hacker.js",    "groupTitle": "Hacker"  },  {    "type": "patch",    "url": "/hacker/:id",    "title": "update a hacker's information.",    "description": "<p>This route only contains the ability to update a subset of a hacker's information. If you want to update a status, you must have Admin priviledges and use PATCH /hacker/status/:id.</p>",    "name": "patchHacker",    "group": "Hacker",    "version": "0.0.8",    "parameter": {      "fields": {        "body": [          {            "group": "body",            "type": "String",            "optional": true,            "field": "school",            "description": "<p>Name of the school the hacker goes to</p>"          },          {            "group": "body",            "type": "String",            "optional": true,            "field": "gender",            "description": "<p>Gender of the hacker</p>"          },          {            "group": "body",            "type": "Boolean",            "optional": true,            "field": "needsBus",            "description": "<p>Whether the hacker requires a bus for transportation</p>"          },          {            "group": "body",            "type": "Json",            "optional": true,            "field": "application",            "description": "<p>The hacker's application</p>"          }        ]      },      "examples": [        {          "title": "application: ",          "content": "{\n    \"portfolioURL\": {\n        \"resume\": \"...\"\n        \"github\": \"...\",\n        \"dropler\": \"...\",\n        \"personal\": \"...\",\n        \"linkedIn\": \"...\",\n        \"other\": \"...\"\n    },\n    \"jobInterest\": \"...\",\n    \"skills\": [\"CSS\", \"HTML\"],    \n    \"comments\": \"...\",\n    \"essay\": \"...\",\n    \"team\": [id1, id2],\n}",          "type": "Json"        }      ]    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>Hacker object</p>"          }        ]      },      "examples": [        {          "title": "Success-Response: ",          "content": "{\n    \"message\": \"Changed hacker information\", \n    \"data\": {...}\n}",          "type": "object"        }      ]    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Error message</p>"          },          {            "group": "Error 4xx",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Error-Response: ",          "content": "{\"message\": \"Error while updating hacker\", \"data\": {}}",          "type": "object"        }      ]    },    "filename": "routes/api/hacker.js",    "groupTitle": "Hacker",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/hacker/:id"      }    ]  },  {    "type": "patch",    "url": "/hacker/status/:id",    "title": "update a hacker's status",    "name": "patchHackerStatus",    "group": "Hacker",    "version": "0.0.9",    "parameter": {      "fields": {        "body": [          {            "group": "body",            "type": "String",            "optional": true,            "field": "status",            "description": "<p>Status of the hacker's application</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>Hacker object</p>"          }        ]      },      "examples": [        {          "title": "Success-Response: ",          "content": "{\n    \"message\": \"Changed hacker information\", \n    \"data\": {\n        \"status\": \"accepted\"\n    }\n}",          "type": "object"        }      ]    },    "permission": [      {        "name": "Administrator"      }    ],    "filename": "routes/api/hacker.js",    "groupTitle": "Hacker",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/hacker/status/:id"      }    ]  },  {    "type": "post",    "url": "/hacker/resume/:id",    "title": "upload or update resume for a hacker.",    "name": "postHackerResume",    "group": "Hacker",    "version": "0.0.8",    "description": "<p><b>NOTE: This must be sent via multipart/form-data POST request</b></p>",    "parameter": {      "fields": {        "param": [          {            "group": "param",            "type": "ObjectId",            "optional": false,            "field": "id",            "description": "<p>Hacker id</p>"          }        ],        "body": [          {            "group": "body",            "type": "File",            "optional": false,            "field": "resume",            "description": "<p>The uploaded file.</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "String",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "Object",            "optional": false,            "field": "data",            "description": "<p>Location in the bucket that the file was stored.</p>"          }        ]      },      "examples": [        {          "title": "Success-Response: ",          "content": "HTTP/1.1 200 OK\n{\n    message: \"Uploaded resume\", \n    data: {\n        filename: \"resumes/1535032624768-507f191e810c19729de860ea\"\n    }\n}",          "type": "json"        }      ]    },    "permission": [      {        "name": "Must be logged in, and the account id must be linked to the hacker."      }    ],    "filename": "routes/api/hacker.js",    "groupTitle": "Hacker",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/hacker/resume/:id"      }    ]  },  {    "type": "get",    "url": "/",    "title": "version",    "version": "0.0.8",    "name": "index",    "group": "Index",    "permission": [      {        "name": "public"      }    ],    "filename": "routes/index.js",    "groupTitle": "Index",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/"      }    ]  },  {    "type": "get",    "url": "/search/:model",    "title": "provide a specific query for any defined model",    "name": "search",    "group": "Search",    "version": "0.0.8",    "parameter": {      "fields": {        "param": [          {            "group": "param",            "type": "String",            "optional": false,            "field": "model",            "description": "<p>the model to be searched</p>"          }        ],        "query": [          {            "group": "query",            "type": "Array",            "optional": false,            "field": "q",            "description": "<p>the query to be executed. For more information on how to format this, please see https://hackerapi.mchacks.ca/architecture/</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "String",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "Object",            "optional": false,            "field": "data",            "description": "<p>Results</p>"          }        ]      },      "examples": [        {          "title": "Success-Response:",          "content": "{\n               \"message\": \"Successfully executed query, returning all results\",\n               \"data\": [\n                   {...}\n               ]\n           }",          "type": "object"        },        {          "title": "Success-Response:",          "content": "{\n               \"message\": \"No results found.\",\n               \"data\": {}\n           }",          "type": "object"        }      ]    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "type": "String",            "optional": false,            "field": "message",            "description": "<p>Error message</p>"          },          {            "group": "Error 4xx",            "type": "Object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Error-Response:",          "content": "{\"message\": \"Validation failed\", \"data\": {}}",          "type": "object"        }      ]    },    "filename": "routes/api/search.js",    "groupTitle": "Search",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/search/:model"      }    ]  },  {    "type": "post",    "url": "/sponsor/",    "title": "create a new sponsor",    "name": "createSponsor",    "group": "Sponsor",    "version": "0.0.8",    "parameter": {      "fields": {        "body": [          {            "group": "body",            "type": "MongoID",            "optional": false,            "field": "accountId",            "description": "<p>ObjectID of the respective account.</p>"          },          {            "group": "body",            "type": "Number",            "optional": false,            "field": "tier",            "description": "<p>Tier of the sponsor, from 0 to 5. 0 is lowest tier, and 5 is the custom tier.</p>"          },          {            "group": "body",            "type": "String",            "optional": false,            "field": "company",            "description": "<p>Name of the company.</p>"          },          {            "group": "body",            "type": "String",            "optional": false,            "field": "contractURL",            "description": "<p>URL link to the contract with the company.</p>"          },          {            "group": "body",            "type": "MongoID[]",            "optional": false,            "field": "nominees",            "description": "<p>Array of accounts that the company wish to nominate as hackers.</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "String",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "Object",            "optional": false,            "field": "data",            "description": "<p>Sponsor object</p>"          }        ]      },      "examples": [        {          "title": "Success-Response: ",          "content": "{\n               \"message\": \"Sponsor creation successful\", \n               \"data\": {...}\n           }",          "type": "object"        }      ]    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "type": "String",            "optional": false,            "field": "message",            "description": "<p>Error message</p>"          },          {            "group": "Error 4xx",            "type": "Object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Error-Response: ",          "content": "{\"message\": \"Error while creating sponsor\", \"data\": {}}",          "type": "object"        }      ]    },    "filename": "routes/api/sponsor.js",    "groupTitle": "Sponsor",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/sponsor/"      }    ]  },  {    "type": "get",    "url": "/sponsor/:id",    "title": "get a sponsor's information",    "name": "getSponsor",    "group": "Sponsor",    "version": "0.0.8",    "parameter": {      "fields": {        "param": [          {            "group": "param",            "type": "string",            "optional": false,            "field": "id",            "description": "<p>a sponsor's unique mongoID</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "String",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "Object",            "optional": false,            "field": "data",            "description": "<p>Sponsor object</p>"          }        ]      },      "examples": [        {          "title": "Success-Response: ",          "content": "{\n               \"message\": \"Successfully retrieved sponsor information\", \n               \"data\": {...}\n           }",          "type": "object"        }      ]    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "type": "String",            "optional": false,            "field": "message",            "description": "<p>Error message</p>"          },          {            "group": "Error 4xx",            "type": "Object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Error-Response: ",          "content": "{\"message\": \"Sponsor not found\", \"data\": {}}",          "type": "object"        }      ]    },    "filename": "routes/api/sponsor.js",    "groupTitle": "Sponsor",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/sponsor/:id"      }    ]  },  {    "type": "post",    "url": "/team/",    "title": "create a new team",    "name": "createTeam",    "group": "Team",    "version": "0.0.8",    "parameter": {      "fields": {        "body": [          {            "group": "body",            "type": "String",            "optional": false,            "field": "name",            "description": "<p>Name of the team.</p>"          },          {            "group": "body",            "type": "MongoID[]",            "optional": true,            "field": "members",            "description": "<p>Array of members in team.</p>"          },          {            "group": "body",            "type": "String",            "optional": true,            "field": "devpostURL",            "description": "<p>Devpost link to hack. Once the link is sent, the hack will be considered to be submitted.</p>"          },          {            "group": "body",            "type": "String",            "optional": false,            "field": "projectName",            "description": "<p>Name of the team.</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>Team object</p>"          }        ]      },      "examples": [        {          "title": "Success-Response: ",          "content": "{\n               \"message\": \"Team creation successful\", \n               \"data\": {...}\n           }",          "type": "object"        }      ]    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Error message</p>"          },          {            "group": "Error 4xx",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Error-Response: ",          "content": "{\"message\": \"Error while creating team\", \"data\": {}}",          "type": "object"        }      ]    },    "filename": "routes/api/team.js",    "groupTitle": "Team",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/team/"      }    ]  },  {    "type": "get",    "url": "/team/:id",    "title": "get a team's information",    "name": "getTeam",    "group": "Team",    "version": "0.0.8",    "parameter": {      "fields": {        "param": [          {            "group": "param",            "type": "ObjectId",            "optional": false,            "field": "id",            "description": "<p>a team's unique mongoId</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "String",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "Object",            "optional": false,            "field": "data",            "description": "<p>Sponsor object</p>"          }        ]      },      "examples": [        {          "title": "Success-Response: ",          "content": "{\n               \"message\": \"Successfully retrieved team information\", \n               \"data\": {...}\n           }",          "type": "object"        }      ]    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "type": "String",            "optional": false,            "field": "message",            "description": "<p>Error message</p>"          },          {            "group": "Error 4xx",            "type": "Object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Error-Response: ",          "content": "{\"message\": \"Team not found\", \"data\": {}}",          "type": "object"        }      ]    },    "filename": "routes/api/team.js",    "groupTitle": "Team",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/team/:id"      }    ]  },  {    "type": "post",    "url": "/volunteer/",    "title": "create a new volunteer",    "name": "createVolunteer",    "group": "Volunteer",    "version": "0.0.8",    "parameter": {      "fields": {        "body": [          {            "group": "body",            "type": "MongoID",            "optional": false,            "field": "accountId",            "description": "<p>MongoID of the account of the volunteer</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>Volunteer object</p>"          }        ]      },      "examples": [        {          "title": "Success-Response: ",          "content": "{\n               \"message\": \"Volunteer creation successful\", \n               \"data\": {...}\n           }",          "type": "object"        }      ]    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Error message</p>"          },          {            "group": "Error 4xx",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Error-Response: ",          "content": "{\"message\": \"Error while creating volunteer\", \"data\": {}}",          "type": "object"        }      ]    },    "filename": "routes/api/volunteer.js",    "groupTitle": "Volunteer",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/volunteer/"      }    ]  }] });
+define({
+  "api": [{
+      "type": "post",
+      "url": "/account/",
+      "title": "create a new account",
+      "name": "create",
+      "group": "Account",
+      "version": "0.0.8",
+      "parameter": {
+        "fields": {
+          "body": [{
+              "group": "body",
+              "type": "String",
+              "optional": false,
+              "field": "firstName",
+              "description": "<p>First name of the account creator.</p>"
+            },
+            {
+              "group": "body",
+              "type": "String",
+              "optional": false,
+              "field": "lastName",
+              "description": "<p>Last name of the account creator.</p>"
+            },
+            {
+              "group": "body",
+              "type": "String",
+              "optional": false,
+              "field": "email",
+              "description": "<p>Email of the account.</p>"
+            },
+            {
+              "group": "body",
+              "type": "String",
+              "optional": false,
+              "field": "dietaryRestrictions",
+              "description": "<p>Any dietary restrictions for the user. 'None' if there are no restrictions</p>"
+            },
+            {
+              "group": "body",
+              "type": "String",
+              "optional": false,
+              "field": "shirtSize",
+              "description": "<p>Size of the shirt that the user will receive.</p>"
+            },
+            {
+              "group": "body",
+              "type": "String",
+              "optional": false,
+              "field": "passowrd",
+              "description": "<p>The password of the account.</p>"
+            }
+          ]
+        }
+      },
+      "success": {
+        "fields": {
+          "Success 200": [{
+              "group": "Success 200",
+              "type": "string",
+              "optional": false,
+              "field": "message",
+              "description": "<p>Success message</p>"
+            },
+            {
+              "group": "Success 200",
+              "type": "object",
+              "optional": false,
+              "field": "data",
+              "description": "<p>Account object</p>"
+            }
+          ]
+        },
+        "examples": [{
+          "title": "Success-Response: ",
+          "content": "{\n               \"message\": \"Account creation successful\", \n               \"data\": {...}\n           }",
+          "type": "object"
+        }]
+      },
+      "error": {
+        "fields": {
+          "Error 4xx": [{
+              "group": "Error 4xx",
+              "type": "string",
+              "optional": false,
+              "field": "message",
+              "description": "<p>Error message</p>"
+            },
+            {
+              "group": "Error 4xx",
+              "type": "object",
+              "optional": false,
+              "field": "data",
+              "description": "<p>empty</p>"
+            }
+          ]
+        },
+        "examples": [{
+          "title": "Error-Response: ",
+          "content": "{\"message\": \"Account already exists\", \"data\": {}}",
+          "type": "object"
+        }]
+      },
+      "filename": "routes/api/account.js",
+      "groupTitle": "Account",
+      "sampleRequest": [{
+        "url": "https://mchacks.ca/api/account/"
+      }]
+    },
+    {
+      "type": "get",
+      "url": "/account/:id",
+      "title": "gets information from an account with mongoid ':id'",
+      "name": "getAccount",
+      "group": "Account",
+      "version": "0.0.8",
+      "parameter": {
+        "fields": {
+          "param": [{
+            "group": "param",
+            "type": "ObjectId",
+            "optional": false,
+            "field": "id",
+            "description": "<p>MongoId of an account</p>"
+          }]
+        }
+      },
+      "success": {
+        "fields": {
+          "Success 200": [{
+              "group": "Success 200",
+              "type": "string",
+              "optional": false,
+              "field": "message",
+              "description": "<p>Success message</p>"
+            },
+            {
+              "group": "Success 200",
+              "type": "object",
+              "optional": false,
+              "field": "data",
+              "description": "<p>Account object</p>"
+            }
+          ]
+        },
+        "examples": [{
+          "title": "Success-Response: ",
+          "content": "{\n               \"message\": \"Account found by user id\", \n               \"data\": {AccountObject}\n           }",
+          "type": "object"
+        }]
+      },
+      "error": {
+        "fields": {
+          "Error 4xx": [{
+              "group": "Error 4xx",
+              "type": "string",
+              "optional": false,
+              "field": "message",
+              "description": "<p>Error message</p>"
+            },
+            {
+              "group": "Error 4xx",
+              "type": "object",
+              "optional": false,
+              "field": "data",
+              "description": "<p>empty</p>"
+            }
+          ]
+        },
+        "examples": [{
+          "title": "Error-Response: ",
+          "content": "{\"message\": \"Account not found\", \"data\": {}}",
+          "type": "object"
+        }]
+      },
+      "filename": "routes/api/account.js",
+      "groupTitle": "Account",
+      "sampleRequest": [{
+        "url": "https://mchacks.ca/api/account/:id"
+      }]
+    },
+    {
+      "type": "get",
+      "url": "/account/self",
+      "title": "get information about own account",
+      "name": "self",
+      "group": "Account",
+      "version": "0.0.8",
+      "success": {
+        "fields": {
+          "Success 200": [{
+              "group": "Success 200",
+              "type": "string",
+              "optional": false,
+              "field": "message",
+              "description": "<p>Success message</p>"
+            },
+            {
+              "group": "Success 200",
+              "type": "object",
+              "optional": false,
+              "field": "data",
+              "description": "<p>Account object</p>"
+            }
+          ]
+        },
+        "examples": [{
+          "title": "Success-Response: ",
+          "content": "{\n               \"message\": \"Account found by user email\", \n               \"data\": {AccountObject}\n           }",
+          "type": "object"
+        }]
+      },
+      "error": {
+        "fields": {
+          "Error 4xx": [{
+              "group": "Error 4xx",
+              "type": "string",
+              "optional": false,
+              "field": "message",
+              "description": "<p>Error message</p>"
+            },
+            {
+              "group": "Error 4xx",
+              "type": "object",
+              "optional": false,
+              "field": "data",
+              "description": "<p>empty</p>"
+            }
+          ]
+        },
+        "examples": [{
+          "title": "Error-Response: ",
+          "content": "{\"message\": \"Account not found\", \"data\": {}}",
+          "type": "object"
+        }]
+      },
+      "filename": "routes/api/account.js",
+      "groupTitle": "Account",
+      "sampleRequest": [{
+        "url": "https://mchacks.ca/api/account/self"
+      }]
+    },
+    {
+      "type": "patch",
+      "url": "/account/:id",
+      "title": "update an account's information",
+      "name": "updateOneUser",
+      "group": "Account",
+      "version": "0.0.8",
+      "parameter": {
+        "fields": {
+          "body": [{
+              "group": "body",
+              "type": "String",
+              "optional": true,
+              "field": "firstName",
+              "description": "<p>First name of the account creator.</p>"
+            },
+            {
+              "group": "body",
+              "type": "String",
+              "optional": true,
+              "field": "lastName",
+              "description": "<p>Last name of the account creator.</p>"
+            },
+            {
+              "group": "body",
+              "type": "String",
+              "optional": true,
+              "field": "email",
+              "description": "<p>Email of the account.</p>"
+            },
+            {
+              "group": "body",
+              "type": "String",
+              "optional": true,
+              "field": "dietaryRestrictions",
+              "description": "<p>Any dietary restrictions for the user. 'None' if there are no restrictions</p>"
+            },
+            {
+              "group": "body",
+              "type": "String",
+              "optional": true,
+              "field": "shirtSize",
+              "description": "<p>Size of the shirt that the user will receive.</p>"
+            },
+            {
+              "group": "body",
+              "type": "String",
+              "optional": true,
+              "field": "passowrd",
+              "description": "<p>The password of the account.</p>"
+            }
+          ]
+        }
+      },
+      "success": {
+        "fields": {
+          "Success 200": [{
+              "group": "Success 200",
+              "type": "string",
+              "optional": false,
+              "field": "message",
+              "description": "<p>Success message</p>"
+            },
+            {
+              "group": "Success 200",
+              "type": "object",
+              "optional": false,
+              "field": "data",
+              "description": "<p>Account object</p>"
+            }
+          ]
+        },
+        "examples": [{
+          "title": "Success-Response: ",
+          "content": "{\n               \"message\": \"Changed account information\", \n               \"data\": {...}\n           }",
+          "type": "object"
+        }]
+      },
+      "error": {
+        "fields": {
+          "Error 4xx": [{
+              "group": "Error 4xx",
+              "type": "string",
+              "optional": false,
+              "field": "message",
+              "description": "<p>Error message</p>"
+            },
+            {
+              "group": "Error 4xx",
+              "type": "object",
+              "optional": false,
+              "field": "data",
+              "description": "<p>empty</p>"
+            }
+          ]
+        },
+        "examples": [{
+          "title": "Error-Response: ",
+          "content": "{\"message\": \"Error while updating account\", \"data\": {}}",
+          "type": "object"
+        }]
+      },
+      "filename": "routes/api/account.js",
+      "groupTitle": "Account",
+      "sampleRequest": [{
+        "url": "https://mchacks.ca/api/account/:id"
+      }]
+    },
+    {
+      "type": "post",
+      "url": "/auth/confirm/:token",
+      "title": "confirm account using the JWT in :token",
+      "name": "confirmAccount",
+      "group": "Authentication",
+      "version": "0.0.8",
+      "parameter": {
+        "fields": {
+          "Parameter": [{
+            "group": "Parameter",
+            "type": "String",
+            "optional": false,
+            "field": "JWT",
+            "description": "<p>for confirming the account</p>"
+          }]
+        }
+      },
+      "success": {
+        "fields": {
+          "Success 200": [{
+              "group": "Success 200",
+              "type": "string",
+              "optional": false,
+              "field": "message",
+              "description": "<p>Success message</p>"
+            },
+            {
+              "group": "Success 200",
+              "type": "object",
+              "optional": false,
+              "field": "data",
+              "description": "<p>empty</p>"
+            }
+          ]
+        },
+        "examples": [{
+          "title": "Success-Response:",
+          "content": "{\"message\": \"Successfully confirmed account\", \"data\": {}}",
+          "type": "json"
+        }]
+      },
+      "error": {
+        "fields": {
+          "Error 4xx": [{
+              "group": "Error 4xx",
+              "type": "string",
+              "optional": false,
+              "field": "message",
+              "description": "<p>Error message</p>"
+            },
+            {
+              "group": "Error 4xx",
+              "type": "object",
+              "optional": false,
+              "field": "data",
+              "description": "<p>empty</p>"
+            }
+          ]
+        },
+        "examples": [{
+          "title": "Error-Response: ",
+          "content": "{\"message\": \"Invalid token for confirming account, \"data\": {}}",
+          "type": "object"
+        }]
+      },
+      "filename": "routes/api/auth.js",
+      "groupTitle": "Authentication",
+      "sampleRequest": [{
+        "url": "https://mchacks.ca/api/auth/confirm/:token"
+      }]
+    },
+    {
+      "type": "post",
+      "url": "/auth/password/forgot",
+      "title": "forgot password route",
+      "name": "forgotPassword",
+      "group": "Authentication",
+      "version": "0.0.8",
+      "parameter": {
+        "fields": {
+          "Parameter": [{
+            "group": "Parameter",
+            "type": "String",
+            "optional": false,
+            "field": "email",
+            "description": "<p>the email address of the account</p>"
+          }]
+        },
+        "examples": [{
+          "title": "Request-Example:",
+          "content": "{ \"email\": \"myemail@mchacks.ca\" }",
+          "type": "json"
+        }]
+      },
+      "success": {
+        "fields": {
+          "Success 200": [{
+              "group": "Success 200",
+              "type": "string",
+              "optional": false,
+              "field": "message",
+              "description": "<p>Success message</p>"
+            },
+            {
+              "group": "Success 200",
+              "type": "object",
+              "optional": false,
+              "field": "data",
+              "description": "<p>empty</p>"
+            }
+          ]
+        },
+        "examples": [{
+          "title": "Success-Response: ",
+          "content": "{\"message\": \"Sent reset email\", \"data\": {}}",
+          "type": "json"
+        }]
+      },
+      "permission": [{
+        "name": ": public"
+      }],
+      "filename": "routes/api/auth.js",
+      "groupTitle": "Authentication",
+      "sampleRequest": [{
+        "url": "https://mchacks.ca/api/auth/password/forgot"
+      }]
+    },
+    {
+      "type": "post",
+      "url": "/auth/login",
+      "title": "login to the service",
+      "name": "login",
+      "group": "Authentication",
+      "version": "0.0.8",
+      "parameter": {
+        "fields": {
+          "Parameter": [{
+              "group": "Parameter",
+              "type": "string",
+              "optional": false,
+              "field": "email",
+              "description": "<p>Account email</p>"
+            },
+            {
+              "group": "Parameter",
+              "type": "string",
+              "optional": false,
+              "field": "password",
+              "description": "<p>Account password</p>"
+            }
+          ]
+        }
+      },
+      "success": {
+        "fields": {
+          "Success 200": [{
+              "group": "Success 200",
+              "type": "string",
+              "optional": false,
+              "field": "message",
+              "description": "<p>Success message</p>"
+            },
+            {
+              "group": "Success 200",
+              "type": "object",
+              "optional": false,
+              "field": "data",
+              "description": "<p>empty</p>"
+            }
+          ]
+        },
+        "examples": [{
+          "title": "Success-Response: ",
+          "content": "{\"message\": \"Successfully logged in\", \"data\": {}}",
+          "type": "object"
+        }]
+      },
+      "error": {
+        "fields": {
+          "Error 4xx": [{
+              "group": "Error 4xx",
+              "type": "string",
+              "optional": false,
+              "field": "message",
+              "description": "<p>Error message</p>"
+            },
+            {
+              "group": "Error 4xx",
+              "type": "object",
+              "optional": false,
+              "field": "data",
+              "description": "<p>empty</p>"
+            }
+          ]
+        },
+        "examples": [{
+          "title": "Error-Response: ",
+          "content": "{\"message\": \"Invalid email or password\", \"data\": {}}",
+          "type": "object"
+        }]
+      },
+      "permission": [{
+        "name": ": public"
+      }],
+      "filename": "routes/api/auth.js",
+      "groupTitle": "Authentication",
+      "sampleRequest": [{
+        "url": "https://mchacks.ca/api/auth/login"
+      }]
+    },
+    {
+      "type": "get",
+      "url": "/auth/logout",
+      "title": "logout of service",
+      "name": "logout",
+      "group": "Authentication",
+      "version": "0.0.8",
+      "success": {
+        "fields": {
+          "Success 200": [{
+              "group": "Success 200",
+              "type": "string",
+              "optional": false,
+              "field": "message",
+              "description": "<p>Success message</p>"
+            },
+            {
+              "group": "Success 200",
+              "type": "object",
+              "optional": false,
+              "field": "data",
+              "description": "<p>empty</p>"
+            }
+          ]
+        },
+        "examples": [{
+          "title": "Success-Response: ",
+          "content": "{\"message\": \"Successfully logged out\", \"data\": {}}",
+          "type": "object"
+        }]
+      },
+      "permission": [{
+        "name": ": public"
+      }],
+      "filename": "routes/api/auth.js",
+      "groupTitle": "Authentication",
+      "sampleRequest": [{
+        "url": "https://mchacks.ca/api/auth/logout"
+      }]
+    },
+    {
+      "type": "get",
+      "url": "/auth/confirm/resend",
+      "title": "resend confirmation token",
+      "name": "resendConfirmAccount",
+      "group": "Authentication",
+      "version": "0.0.8",
+      "success": {
+        "fields": {
+          "Success 200": [{
+              "group": "Success 200",
+              "type": "string",
+              "optional": false,
+              "field": "message",
+              "description": "<p>Success message</p>"
+            },
+            {
+              "group": "Success 200",
+              "type": "object",
+              "optional": false,
+              "field": "data",
+              "description": "<p>empty</p>"
+            }
+          ]
+        },
+        "examples": [{
+          "title": "Success-Response:",
+          "content": "{\"message\": \"Successfully resent confirmation email\", \"data\": {}}",
+          "type": "json"
+        }]
+      },
+      "error": {
+        "fields": {
+          "Error 4xx": [{
+              "group": "Error 4xx",
+              "type": "string",
+              "optional": false,
+              "field": "message",
+              "description": "<p>Error message</p>"
+            },
+            {
+              "group": "Error 4xx",
+              "type": "object",
+              "optional": false,
+              "field": "data",
+              "description": "<p>empty</p>"
+            }
+          ]
+        },
+        "examples": [{
+            "title": "Error-Response:",
+            "content": " HTTP/1.1 422\n{\"message\": \"Account already confirmed, \"data\": {}}",
+            "type": "json"
+          },
+          {
+            "title": "Error-Response:",
+            "content": " HTTP/1.1 428\n{\"message\": \"Account already confirmed, \"data\": {}}",
+            "type": "json"
+          }
+        ]
+      },
+      "filename": "routes/api/auth.js",
+      "groupTitle": "Authentication",
+      "sampleRequest": [{
+        "url": "https://mchacks.ca/api/auth/confirm/resend"
+      }]
+    },
+    {
+      "type": "post",
+      "url": "/auth/password/reset",
+      "title": "reset password",
+      "name": "resetPassword",
+      "group": "Authentication",
+      "version": "0.0.8",
+      "parameter": {
+        "fields": {
+          "Parameter": [{
+            "group": "Parameter",
+            "type": "String",
+            "optional": false,
+            "field": "password",
+            "description": "<p>the password of the account</p>"
+          }]
+        },
+        "examples": [{
+          "title": "Request-Example:",
+          "content": "{ \"password\": \"hunter2\" }",
+          "type": "json"
+        }]
+      },
+      "header": {
+        "fields": {
+          "Header": [{
+            "group": "Header",
+            "type": "String",
+            "optional": false,
+            "field": "Authentication",
+            "description": "<p>the token that was provided in the reset password email</p>"
+          }]
+        },
+        "examples": [{
+          "title": "Header-Example:",
+          "content": "{\n  \"X-Reset-Token\": \"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c\"\n}",
+          "type": "json"
+        }]
+      },
+      "success": {
+        "fields": {
+          "Success 200": [{
+              "group": "Success 200",
+              "type": "string",
+              "optional": false,
+              "field": "message",
+              "description": "<p>Success message</p>"
+            },
+            {
+              "group": "Success 200",
+              "type": "object",
+              "optional": false,
+              "field": "data",
+              "description": "<p>empty</p>"
+            }
+          ]
+        },
+        "examples": [{
+          "title": "Success-Response: ",
+          "content": "{\"message\": \"Successfully reset password\", \"data\": {}}",
+          "type": "json"
+        }]
+      },
+      "permission": [{
+        "name": ": must have authentication token"
+      }],
+      "filename": "routes/api/auth.js",
+      "groupTitle": "Authentication",
+      "sampleRequest": [{
+        "url": "https://mchacks.ca/api/auth/password/reset"
+      }]
+    },
+    {
+      "type": "get",
+      "url": "/auth/rolebindings/:id",
+      "title": "retrieve rolebindings for a user given by their user id :id",
+      "name": "getRoleBindings",
+      "group": "Auth",
+      "version": "0.0.8",
+      "parameter": {
+        "fields": {
+          "param": [{
+            "group": "param",
+            "type": "ObjectId",
+            "optional": false,
+            "field": "id",
+            "description": "<p>MongoId of an account</p>"
+          }]
+        }
+      },
+      "success": {
+        "fields": {
+          "Success 200": [{
+              "group": "Success 200",
+              "type": "string",
+              "optional": false,
+              "field": "message",
+              "description": "<p>Success message</p>"
+            },
+            {
+              "group": "Success 200",
+              "type": "object",
+              "optional": false,
+              "field": "data",
+              "description": "<p>Rolebindings object</p>"
+            }
+          ]
+        },
+        "examples": [{
+          "title": "Success-Response: ",
+          "content": "{\n               \"message\": \"Successfully retrieved role bindings\",\n               \"data\": {\n                   accountId:\"5beca4ab2e069a34f91697b2\"\n                   id:\"5beca4ae2e069a34f91698b1\"\n                   roles: [\n                       {\n                           _id:\"5beca4ab2e069a34f91697d9\",\n                           name:\"hacker\",\n                           routes: [\n                               0:Object {_id: \"5beca4ae2e069a34f9169852\", requestType: \"POST\", uri: \"/api/auth/login\"},\n                               1:Object {_id: \"5beca4ae2e069a34f9169851\", requestType: \"POST\", uri: \"/api/auth/logout\"},\n                               2:Object {_id: \"5beca4ae2e069a34f9169850\", requestType: \"GET\", uri: \"/api/auth/rolebindings/:self\"},\n                               3:Object {_id: \"5beca4ae2e069a34f916984f\", requestType: \"GET\", uri: \"/api/account/self\"},\n                               4:Object {_id: \"5beca4ae2e069a34f916984e\", requestType: \"GET\", uri: \"/api/account/:self\"},\n                               5:Object {_id: \"5beca4ae2e069a34f916984d\", requestType: \"PATCH\", uri: \"/api/account/:self\"},\n                               6:Object {_id: \"5beca4ae2e069a34f916984c\", requestType: \"POST\", uri: \"/api/hacker/\"},\n                               7:Object {_id: \"5beca4ae2e069a34f916984b\", requestType: \"GET\", uri: \"/api/hacker/:self\"},\n                               8:Object {_id: \"5beca4ae2e069a34f916984a\", requestType: \"GET\", uri: \"/api/hacker/:self/resume\"},\n                               9:Object {_id: \"5beca4ae2e069a34f9169849\", requestType: \"PATCH\", uri: \"/api/hacker/:self\"}\n                           ]\n                       }\n                   ]\n               }\n           }",
+          "type": "object"
+        }]
+      },
+      "error": {
+        "fields": {
+          "Error 4xx": [{
+              "group": "Error 4xx",
+              "type": "string",
+              "optional": false,
+              "field": "message",
+              "description": "<p>Error message</p>"
+            },
+            {
+              "group": "Error 4xx",
+              "type": "object",
+              "optional": false,
+              "field": "data",
+              "description": "<p>empty</p>"
+            }
+          ]
+        },
+        "examples": [{
+          "title": "Error-Response: ",
+          "content": "{\"message\": \"Role Bindings not found\", \"data\": {}}",
+          "type": "object"
+        }]
+      },
+      "filename": "routes/api/auth.js",
+      "groupTitle": "Auth",
+      "sampleRequest": [{
+        "url": "https://mchacks.ca/api/auth/rolebindings/:id"
+      }]
+    },
+    {
+      "type": "post",
+      "url": "/hacker/",
+      "title": "create a new hacker",
+      "name": "createHacker",
+      "group": "Hacker",
+      "version": "0.0.8",
+      "parameter": {
+        "fields": {
+          "body": [{
+              "group": "body",
+              "type": "MongoID",
+              "optional": false,
+              "field": "accountId",
+              "description": "<p>ObjectID of the respective account</p>"
+            },
+            {
+              "group": "body",
+              "type": "String",
+              "optional": false,
+              "field": "school",
+              "description": "<p>Name of the school the hacker goes to</p>"
+            },
+            {
+              "group": "body",
+              "type": "String",
+              "optional": false,
+              "field": "gender",
+              "description": "<p>Gender of the hacker</p>"
+            },
+            {
+              "group": "body",
+              "type": "Boolean",
+              "optional": false,
+              "field": "needsBus",
+              "description": "<p>Whether the hacker requires a bus for transportation</p>"
+            },
+            {
+              "group": "body",
+              "type": "Json",
+              "optional": false,
+              "field": "application",
+              "description": "<p>The hacker's application. Resume and jobInterest fields are required.</p>"
+            }
+          ]
+        },
+        "examples": [{
+          "title": "application: ",
+          "content": "{\n    \"portfolioURL\": {\n        \"resume\": \"...\"\n        \"github\": \"...\",\n        \"dropler\": \"...\",\n        \"personal\": \"...\",\n        \"linkedIn\": \"...\",\n        \"other\": \"...\"\n    },\n    \"jobInterest\": \"...\",\n    \"skills\": [\"CSS\", \"HTML\"],    \n    \"comments\": \"...\",\n    \"essay\": \"...\",\n    \"team\": [id1, id2],\n}",
+          "type": "Json"
+        }]
+      },
+      "success": {
+        "fields": {
+          "Success 200": [{
+              "group": "Success 200",
+              "type": "string",
+              "optional": false,
+              "field": "message",
+              "description": "<p>Success message</p>"
+            },
+            {
+              "group": "Success 200",
+              "type": "object",
+              "optional": false,
+              "field": "data",
+              "description": "<p>Hacker object</p>"
+            }
+          ]
+        },
+        "examples": [{
+          "title": "Success-Response: ",
+          "content": "{\n    \"message\": \"Hacker creation successful\", \n    \"data\": {...}\n}",
+          "type": "object"
+        }]
+      },
+      "error": {
+        "fields": {
+          "Error 4xx": [{
+              "group": "Error 4xx",
+              "type": "string",
+              "optional": false,
+              "field": "message",
+              "description": "<p>Error message</p>"
+            },
+            {
+              "group": "Error 4xx",
+              "type": "object",
+              "optional": false,
+              "field": "data",
+              "description": "<p>empty</p>"
+            }
+          ]
+        },
+        "examples": [{
+          "title": "Error-Response: ",
+          "content": "{\"message\": \"Error while creating hacker\", \"data\": {}}",
+          "type": "object"
+        }]
+      },
+      "filename": "routes/api/hacker.js",
+      "groupTitle": "Hacker",
+      "sampleRequest": [{
+        "url": "https://mchacks.ca/api/hacker/"
+      }]
+    },
+    {
+      "type": "get",
+      "url": "/hacker/:id",
+      "title": "get a hacker's information",
+      "name": "getHacker",
+      "group": "Hacker",
+      "version": "0.0.8",
+      "parameter": {
+        "fields": {
+          "param": [{
+            "group": "param",
+            "type": "String",
+            "optional": false,
+            "field": "id",
+            "description": "<p>a hacker's unique mongoID</p>"
+          }]
+        }
+      },
+      "success": {
+        "fields": {
+          "Success 200": [{
+              "group": "Success 200",
+              "type": "String",
+              "optional": false,
+              "field": "message",
+              "description": "<p>Success message</p>"
+            },
+            {
+              "group": "Success 200",
+              "type": "Object",
+              "optional": false,
+              "field": "data",
+              "description": "<p>Sponsor object</p>"
+            }
+          ]
+        },
+        "examples": [{
+          "title": "Success-Response: ",
+          "content": "{\n               \"message\": \"Successfully retrieved hacker information\", \n               \"data\": {...}\n           }",
+          "type": "object"
+        }]
+      },
+      "error": {
+        "fields": {
+          "Error 4xx": [{
+              "group": "Error 4xx",
+              "type": "String",
+              "optional": false,
+              "field": "message",
+              "description": "<p>Error message</p>"
+            },
+            {
+              "group": "Error 4xx",
+              "type": "Object",
+              "optional": false,
+              "field": "data",
+              "description": "<p>empty</p>"
+            }
+          ]
+        },
+        "examples": [{
+          "title": "Error-Response: ",
+          "content": "{\"message\": \"Hacker not found\", \"data\": {}}",
+          "type": "object"
+        }]
+      },
+      "filename": "routes/api/hacker.js",
+      "groupTitle": "Hacker",
+      "sampleRequest": [{
+        "url": "https://mchacks.ca/api/hacker/:id"
+      }]
+    },
+    {
+      "type": "get",
+      "url": "/hacker/resume:id",
+      "title": "get the resume for a hacker.",
+      "name": "getHackerResume",
+      "group": "Hacker",
+      "version": "0.0.8",
+      "parameter": {
+        "fields": {
+          "param": [{
+            "group": "param",
+            "type": "ObjectId",
+            "optional": false,
+            "field": "id",
+            "description": "<p>Hacker id</p>"
+          }]
+        }
+      },
+      "success": {
+        "fields": {
+          "Success 200": [{
+            "group": "Success 200",
+            "type": "String",
+            "optional": false,
+            "field": "message",
+            "description": "<p>Success message</p>"
+          }]
+        },
+        "examples": [{
+          "title": "Success-Response:",
+          "content": "HTTP/1.1 200 OK \n{ \n    message: \"Downloaded resume\", \n    data: { \n        id: \"507f191e810c19729de860ea\", \n        resume: [Buffer] \n    } \n}",
+          "type": "json"
+        }]
+      },
+      "error": {
+        "fields": {
+          "Error 4xx": [{
+            "group": "Error 4xx",
+            "type": "String",
+            "optional": false,
+            "field": "message",
+            "description": "<p>&quot;Resume does not exist&quot;</p>"
+          }]
+        },
+        "examples": [{
+          "title": "Error-Response:",
+          "content": "HTTP/1.1 404 \n{ \n    message: \"Resume not found\", \n    data: {} \n}",
+          "type": "json"
+        }]
+      },
+      "permission": [{
+        "name": "Must be logged in, and the account id must be linked to the hacker."
+      }],
+      "filename": "routes/api/hacker.js",
+      "groupTitle": "Hacker"
+    },
+    {
+      "type": "patch",
+      "url": "/hacker/:id",
+      "title": "update a hacker's information.",
+      "description": "<p>This route only contains the ability to update a subset of a hacker's information. If you want to update a status, you must have Admin priviledges and use PATCH /hacker/status/:id.</p>",
+      "name": "patchHacker",
+      "group": "Hacker",
+      "version": "0.0.8",
+      "parameter": {
+        "fields": {
+          "body": [{
+              "group": "body",
+              "type": "String",
+              "optional": true,
+              "field": "school",
+              "description": "<p>Name of the school the hacker goes to</p>"
+            },
+            {
+              "group": "body",
+              "type": "String",
+              "optional": true,
+              "field": "gender",
+              "description": "<p>Gender of the hacker</p>"
+            },
+            {
+              "group": "body",
+              "type": "Boolean",
+              "optional": true,
+              "field": "needsBus",
+              "description": "<p>Whether the hacker requires a bus for transportation</p>"
+            },
+            {
+              "group": "body",
+              "type": "Json",
+              "optional": true,
+              "field": "application",
+              "description": "<p>The hacker's application</p>"
+            }
+          ]
+        },
+        "examples": [{
+          "title": "application: ",
+          "content": "{\n    \"portfolioURL\": {\n        \"resume\": \"...\"\n        \"github\": \"...\",\n        \"dropler\": \"...\",\n        \"personal\": \"...\",\n        \"linkedIn\": \"...\",\n        \"other\": \"...\"\n    },\n    \"jobInterest\": \"...\",\n    \"skills\": [\"CSS\", \"HTML\"],    \n    \"comments\": \"...\",\n    \"essay\": \"...\",\n    \"team\": [id1, id2],\n}",
+          "type": "Json"
+        }]
+      },
+      "success": {
+        "fields": {
+          "Success 200": [{
+              "group": "Success 200",
+              "type": "string",
+              "optional": false,
+              "field": "message",
+              "description": "<p>Success message</p>"
+            },
+            {
+              "group": "Success 200",
+              "type": "object",
+              "optional": false,
+              "field": "data",
+              "description": "<p>Hacker object</p>"
+            }
+          ]
+        },
+        "examples": [{
+          "title": "Success-Response: ",
+          "content": "{\n    \"message\": \"Changed hacker information\", \n    \"data\": {...}\n}",
+          "type": "object"
+        }]
+      },
+      "error": {
+        "fields": {
+          "Error 4xx": [{
+              "group": "Error 4xx",
+              "type": "string",
+              "optional": false,
+              "field": "message",
+              "description": "<p>Error message</p>"
+            },
+            {
+              "group": "Error 4xx",
+              "type": "object",
+              "optional": false,
+              "field": "data",
+              "description": "<p>empty</p>"
+            }
+          ]
+        },
+        "examples": [{
+          "title": "Error-Response: ",
+          "content": "{\"message\": \"Error while updating hacker\", \"data\": {}}",
+          "type": "object"
+        }]
+      },
+      "filename": "routes/api/hacker.js",
+      "groupTitle": "Hacker",
+      "sampleRequest": [{
+        "url": "https://mchacks.ca/api/hacker/:id"
+      }]
+    },
+    {
+      "type": "patch",
+      "url": "/hacker/status/:id",
+      "title": "update a hacker's status",
+      "name": "patchHackerStatus",
+      "group": "Hacker",
+      "version": "0.0.9",
+      "parameter": {
+        "fields": {
+          "body": [{
+            "group": "body",
+            "type": "String",
+            "optional": true,
+            "field": "status",
+            "description": "<p>Status of the hacker's application</p>"
+          }]
+        }
+      },
+      "success": {
+        "fields": {
+          "Success 200": [{
+              "group": "Success 200",
+              "type": "string",
+              "optional": false,
+              "field": "message",
+              "description": "<p>Success message</p>"
+            },
+            {
+              "group": "Success 200",
+              "type": "object",
+              "optional": false,
+              "field": "data",
+              "description": "<p>Hacker object</p>"
+            }
+          ]
+        },
+        "examples": [{
+          "title": "Success-Response: ",
+          "content": "{\n    \"message\": \"Changed hacker information\", \n    \"data\": {\n        \"status\": \"accepted\"\n    }\n}",
+          "type": "object"
+        }]
+      },
+      "permission": [{
+        "name": "Administrator"
+      }],
+      "filename": "routes/api/hacker.js",
+      "groupTitle": "Hacker",
+      "sampleRequest": [{
+        "url": "https://mchacks.ca/api/hacker/status/:id"
+      }]
+    },
+    {
+      "type": "post",
+      "url": "/hacker/resume/:id",
+      "title": "upload or update resume for a hacker.",
+      "name": "postHackerResume",
+      "group": "Hacker",
+      "version": "0.0.8",
+      "description": "<p><b>NOTE: This must be sent via multipart/form-data POST request</b></p>",
+      "parameter": {
+        "fields": {
+          "param": [{
+            "group": "param",
+            "type": "ObjectId",
+            "optional": false,
+            "field": "id",
+            "description": "<p>Hacker id</p>"
+          }],
+          "body": [{
+            "group": "body",
+            "type": "File",
+            "optional": false,
+            "field": "resume",
+            "description": "<p>The uploaded file.</p>"
+          }]
+        }
+      },
+      "success": {
+        "fields": {
+          "Success 200": [{
+              "group": "Success 200",
+              "type": "String",
+              "optional": false,
+              "field": "message",
+              "description": "<p>Success message</p>"
+            },
+            {
+              "group": "Success 200",
+              "type": "Object",
+              "optional": false,
+              "field": "data",
+              "description": "<p>Location in the bucket that the file was stored.</p>"
+            }
+          ]
+        },
+        "examples": [{
+          "title": "Success-Response: ",
+          "content": "HTTP/1.1 200 OK\n{\n    message: \"Uploaded resume\", \n    data: {\n        filename: \"resumes/1535032624768-507f191e810c19729de860ea\"\n    }\n}",
+          "type": "json"
+        }]
+      },
+      "permission": [{
+        "name": "Must be logged in, and the account id must be linked to the hacker."
+      }],
+      "filename": "routes/api/hacker.js",
+      "groupTitle": "Hacker",
+      "sampleRequest": [{
+        "url": "https://mchacks.ca/api/hacker/resume/:id"
+      }]
+    },
+    {
+      "type": "get",
+      "url": "/",
+      "title": "version",
+      "version": "0.0.8",
+      "name": "index",
+      "group": "Index",
+      "permission": [{
+        "name": "public"
+      }],
+      "filename": "routes/index.js",
+      "groupTitle": "Index",
+      "sampleRequest": [{
+        "url": "https://mchacks.ca/api/"
+      }]
+    },
+    {
+      "type": "get",
+      "url": "/search/:model",
+      "title": "provide a specific query for any defined model",
+      "name": "search",
+      "group": "Search",
+      "version": "0.0.8",
+      "parameter": {
+        "fields": {
+          "param": [{
+            "group": "param",
+            "type": "String",
+            "optional": false,
+            "field": "model",
+            "description": "<p>the model to be searched</p>"
+          }],
+          "query": [{
+            "group": "query",
+            "type": "Array",
+            "optional": false,
+            "field": "q",
+            "description": "<p>the query to be executed. For more information on how to format this, please see https://hackerapi.mchacks.ca/architecture/</p>"
+          }]
+        }
+      },
+      "success": {
+        "fields": {
+          "Success 200": [{
+              "group": "Success 200",
+              "type": "String",
+              "optional": false,
+              "field": "message",
+              "description": "<p>Success message</p>"
+            },
+            {
+              "group": "Success 200",
+              "type": "Object",
+              "optional": false,
+              "field": "data",
+              "description": "<p>Results</p>"
+            }
+          ]
+        },
+        "examples": [{
+            "title": "Success-Response:",
+            "content": "{\n               \"message\": \"Successfully executed query, returning all results\",\n               \"data\": [\n                   {...}\n               ]\n           }",
+            "type": "object"
+          },
+          {
+            "title": "Success-Response:",
+            "content": "{\n               \"message\": \"No results found.\",\n               \"data\": {}\n           }",
+            "type": "object"
+          }
+        ]
+      },
+      "error": {
+        "fields": {
+          "Error 4xx": [{
+              "group": "Error 4xx",
+              "type": "String",
+              "optional": false,
+              "field": "message",
+              "description": "<p>Error message</p>"
+            },
+            {
+              "group": "Error 4xx",
+              "type": "Object",
+              "optional": false,
+              "field": "data",
+              "description": "<p>empty</p>"
+            }
+          ]
+        },
+        "examples": [{
+          "title": "Error-Response:",
+          "content": "{\"message\": \"Validation failed\", \"data\": {}}",
+          "type": "object"
+        }]
+      },
+      "filename": "routes/api/search.js",
+      "groupTitle": "Search",
+      "sampleRequest": [{
+        "url": "https://mchacks.ca/api/search/:model"
+      }]
+    },
+    {
+      "type": "post",
+      "url": "/sponsor/",
+      "title": "create a new sponsor",
+      "name": "createSponsor",
+      "group": "Sponsor",
+      "version": "0.0.8",
+      "parameter": {
+        "fields": {
+          "body": [{
+              "group": "body",
+              "type": "MongoID",
+              "optional": false,
+              "field": "accountId",
+              "description": "<p>ObjectID of the respective account.</p>"
+            },
+            {
+              "group": "body",
+              "type": "Number",
+              "optional": false,
+              "field": "tier",
+              "description": "<p>Tier of the sponsor, from 0 to 5. 0 is lowest tier, and 5 is the custom tier.</p>"
+            },
+            {
+              "group": "body",
+              "type": "String",
+              "optional": false,
+              "field": "company",
+              "description": "<p>Name of the company.</p>"
+            },
+            {
+              "group": "body",
+              "type": "String",
+              "optional": false,
+              "field": "contractURL",
+              "description": "<p>URL link to the contract with the company.</p>"
+            },
+            {
+              "group": "body",
+              "type": "MongoID[]",
+              "optional": false,
+              "field": "nominees",
+              "description": "<p>Array of accounts that the company wish to nominate as hackers.</p>"
+            }
+          ]
+        }
+      },
+      "success": {
+        "fields": {
+          "Success 200": [{
+              "group": "Success 200",
+              "type": "String",
+              "optional": false,
+              "field": "message",
+              "description": "<p>Success message</p>"
+            },
+            {
+              "group": "Success 200",
+              "type": "Object",
+              "optional": false,
+              "field": "data",
+              "description": "<p>Sponsor object</p>"
+            }
+          ]
+        },
+        "examples": [{
+          "title": "Success-Response: ",
+          "content": "{\n               \"message\": \"Sponsor creation successful\", \n               \"data\": {...}\n           }",
+          "type": "object"
+        }]
+      },
+      "error": {
+        "fields": {
+          "Error 4xx": [{
+              "group": "Error 4xx",
+              "type": "String",
+              "optional": false,
+              "field": "message",
+              "description": "<p>Error message</p>"
+            },
+            {
+              "group": "Error 4xx",
+              "type": "Object",
+              "optional": false,
+              "field": "data",
+              "description": "<p>empty</p>"
+            }
+          ]
+        },
+        "examples": [{
+          "title": "Error-Response: ",
+          "content": "{\"message\": \"Error while creating sponsor\", \"data\": {}}",
+          "type": "object"
+        }]
+      },
+      "filename": "routes/api/sponsor.js",
+      "groupTitle": "Sponsor",
+      "sampleRequest": [{
+        "url": "https://mchacks.ca/api/sponsor/"
+      }]
+    },
+    {
+      "type": "get",
+      "url": "/sponsor/:id",
+      "title": "get a sponsor's information",
+      "name": "getSponsor",
+      "group": "Sponsor",
+      "version": "0.0.8",
+      "parameter": {
+        "fields": {
+          "param": [{
+            "group": "param",
+            "type": "string",
+            "optional": false,
+            "field": "id",
+            "description": "<p>a sponsor's unique mongoID</p>"
+          }]
+        }
+      },
+      "success": {
+        "fields": {
+          "Success 200": [{
+              "group": "Success 200",
+              "type": "String",
+              "optional": false,
+              "field": "message",
+              "description": "<p>Success message</p>"
+            },
+            {
+              "group": "Success 200",
+              "type": "Object",
+              "optional": false,
+              "field": "data",
+              "description": "<p>Sponsor object</p>"
+            }
+          ]
+        },
+        "examples": [{
+          "title": "Success-Response: ",
+          "content": "{\n               \"message\": \"Successfully retrieved sponsor information\", \n               \"data\": {...}\n           }",
+          "type": "object"
+        }]
+      },
+      "error": {
+        "fields": {
+          "Error 4xx": [{
+              "group": "Error 4xx",
+              "type": "String",
+              "optional": false,
+              "field": "message",
+              "description": "<p>Error message</p>"
+            },
+            {
+              "group": "Error 4xx",
+              "type": "Object",
+              "optional": false,
+              "field": "data",
+              "description": "<p>empty</p>"
+            }
+          ]
+        },
+        "examples": [{
+          "title": "Error-Response: ",
+          "content": "{\"message\": \"Sponsor not found\", \"data\": {}}",
+          "type": "object"
+        }]
+      },
+      "filename": "routes/api/sponsor.js",
+      "groupTitle": "Sponsor",
+      "sampleRequest": [{
+        "url": "https://mchacks.ca/api/sponsor/:id"
+      }]
+    },
+    {
+      "type": "post",
+      "url": "/team/",
+      "title": "create a new team",
+      "name": "createTeam",
+      "group": "Team",
+      "version": "0.0.8",
+      "parameter": {
+        "fields": {
+          "body": [{
+              "group": "body",
+              "type": "String",
+              "optional": false,
+              "field": "name",
+              "description": "<p>Name of the team.</p>"
+            },
+            {
+              "group": "body",
+              "type": "MongoID[]",
+              "optional": true,
+              "field": "members",
+              "description": "<p>Array of members in team.</p>"
+            },
+            {
+              "group": "body",
+              "type": "String",
+              "optional": true,
+              "field": "devpostURL",
+              "description": "<p>Devpost link to hack. Once the link is sent, the hack will be considered to be submitted.</p>"
+            },
+            {
+              "group": "body",
+              "type": "String",
+              "optional": false,
+              "field": "projectName",
+              "description": "<p>Name of the team.</p>"
+            }
+          ]
+        }
+      },
+      "success": {
+        "fields": {
+          "Success 200": [{
+              "group": "Success 200",
+              "type": "string",
+              "optional": false,
+              "field": "message",
+              "description": "<p>Success message</p>"
+            },
+            {
+              "group": "Success 200",
+              "type": "object",
+              "optional": false,
+              "field": "data",
+              "description": "<p>Team object</p>"
+            }
+          ]
+        },
+        "examples": [{
+          "title": "Success-Response: ",
+          "content": "{\n               \"message\": \"Team creation successful\", \n               \"data\": {...}\n           }",
+          "type": "object"
+        }]
+      },
+      "error": {
+        "fields": {
+          "Error 4xx": [{
+              "group": "Error 4xx",
+              "type": "string",
+              "optional": false,
+              "field": "message",
+              "description": "<p>Error message</p>"
+            },
+            {
+              "group": "Error 4xx",
+              "type": "object",
+              "optional": false,
+              "field": "data",
+              "description": "<p>empty</p>"
+            }
+          ]
+        },
+        "examples": [{
+          "title": "Error-Response: ",
+          "content": "{\"message\": \"Error while creating team\", \"data\": {}}",
+          "type": "object"
+        }]
+      },
+      "filename": "routes/api/team.js",
+      "groupTitle": "Team",
+      "sampleRequest": [{
+        "url": "https://mchacks.ca/api/team/"
+      }]
+    },
+    {
+      "type": "get",
+      "url": "/team/:id",
+      "title": "get a team's information",
+      "name": "getTeam",
+      "group": "Team",
+      "version": "0.0.8",
+      "parameter": {
+        "fields": {
+          "param": [{
+            "group": "param",
+            "type": "ObjectId",
+            "optional": false,
+            "field": "id",
+            "description": "<p>a team's unique mongoId</p>"
+          }]
+        }
+      },
+      "success": {
+        "fields": {
+          "Success 200": [{
+              "group": "Success 200",
+              "type": "String",
+              "optional": false,
+              "field": "message",
+              "description": "<p>Success message</p>"
+            },
+            {
+              "group": "Success 200",
+              "type": "Object",
+              "optional": false,
+              "field": "data",
+              "description": "<p>Sponsor object</p>"
+            }
+          ]
+        },
+        "examples": [{
+          "title": "Success-Response: ",
+          "content": "{\n               \"message\": \"Successfully retrieved team information\", \n               \"data\": {...}\n           }",
+          "type": "object"
+        }]
+      },
+      "error": {
+        "fields": {
+          "Error 4xx": [{
+              "group": "Error 4xx",
+              "type": "String",
+              "optional": false,
+              "field": "message",
+              "description": "<p>Error message</p>"
+            },
+            {
+              "group": "Error 4xx",
+              "type": "Object",
+              "optional": false,
+              "field": "data",
+              "description": "<p>empty</p>"
+            }
+          ]
+        },
+        "examples": [{
+          "title": "Error-Response: ",
+          "content": "{\"message\": \"Team not found\", \"data\": {}}",
+          "type": "object"
+        }]
+      },
+      "filename": "routes/api/team.js",
+      "groupTitle": "Team",
+      "sampleRequest": [{
+        "url": "https://mchacks.ca/api/team/:id"
+      }]
+    },
+    {
+      "type": "post",
+      "url": "/volunteer/",
+      "title": "create a new volunteer",
+      "name": "createVolunteer",
+      "group": "Volunteer",
+      "version": "0.0.8",
+      "parameter": {
+        "fields": {
+          "body": [{
+            "group": "body",
+            "type": "MongoID",
+            "optional": false,
+            "field": "accountId",
+            "description": "<p>MongoID of the account of the volunteer</p>"
+          }]
+        }
+      },
+      "success": {
+        "fields": {
+          "Success 200": [{
+              "group": "Success 200",
+              "type": "string",
+              "optional": false,
+              "field": "message",
+              "description": "<p>Success message</p>"
+            },
+            {
+              "group": "Success 200",
+              "type": "object",
+              "optional": false,
+              "field": "data",
+              "description": "<p>Volunteer object</p>"
+            }
+          ]
+        },
+        "examples": [{
+          "title": "Success-Response: ",
+          "content": "{\n               \"message\": \"Volunteer creation successful\", \n               \"data\": {...}\n           }",
+          "type": "object"
+        }]
+      },
+      "error": {
+        "fields": {
+          "Error 4xx": [{
+              "group": "Error 4xx",
+              "type": "string",
+              "optional": false,
+              "field": "message",
+              "description": "<p>Error message</p>"
+            },
+            {
+              "group": "Error 4xx",
+              "type": "object",
+              "optional": false,
+              "field": "data",
+              "description": "<p>empty</p>"
+            }
+          ]
+        },
+        "examples": [{
+          "title": "Error-Response: ",
+          "content": "{\"message\": \"Error while creating volunteer\", \"data\": {}}",
+          "type": "object"
+        }]
+      },
+      "filename": "routes/api/volunteer.js",
+      "groupTitle": "Volunteer",
+      "sampleRequest": [{
+        "url": "https://mchacks.ca/api/volunteer/"
+      }]
+    }
+  ]
+});

--- a/docs/api/api_data.js
+++ b/docs/api/api_data.js
@@ -1,1770 +1,1 @@
-define({
-  "api": [{
-      "type": "post",
-      "url": "/account/",
-      "title": "create a new account",
-      "name": "create",
-      "group": "Account",
-      "version": "0.0.8",
-      "parameter": {
-        "fields": {
-          "body": [{
-              "group": "body",
-              "type": "String",
-              "optional": false,
-              "field": "firstName",
-              "description": "<p>First name of the account creator.</p>"
-            },
-            {
-              "group": "body",
-              "type": "String",
-              "optional": false,
-              "field": "lastName",
-              "description": "<p>Last name of the account creator.</p>"
-            },
-            {
-              "group": "body",
-              "type": "String",
-              "optional": false,
-              "field": "email",
-              "description": "<p>Email of the account.</p>"
-            },
-            {
-              "group": "body",
-              "type": "String",
-              "optional": false,
-              "field": "dietaryRestrictions",
-              "description": "<p>Any dietary restrictions for the user. 'None' if there are no restrictions</p>"
-            },
-            {
-              "group": "body",
-              "type": "String",
-              "optional": false,
-              "field": "shirtSize",
-              "description": "<p>Size of the shirt that the user will receive.</p>"
-            },
-            {
-              "group": "body",
-              "type": "String",
-              "optional": false,
-              "field": "passowrd",
-              "description": "<p>The password of the account.</p>"
-            }
-          ]
-        }
-      },
-      "success": {
-        "fields": {
-          "Success 200": [{
-              "group": "Success 200",
-              "type": "string",
-              "optional": false,
-              "field": "message",
-              "description": "<p>Success message</p>"
-            },
-            {
-              "group": "Success 200",
-              "type": "object",
-              "optional": false,
-              "field": "data",
-              "description": "<p>Account object</p>"
-            }
-          ]
-        },
-        "examples": [{
-          "title": "Success-Response: ",
-          "content": "{\n               \"message\": \"Account creation successful\", \n               \"data\": {...}\n           }",
-          "type": "object"
-        }]
-      },
-      "error": {
-        "fields": {
-          "Error 4xx": [{
-              "group": "Error 4xx",
-              "type": "string",
-              "optional": false,
-              "field": "message",
-              "description": "<p>Error message</p>"
-            },
-            {
-              "group": "Error 4xx",
-              "type": "object",
-              "optional": false,
-              "field": "data",
-              "description": "<p>empty</p>"
-            }
-          ]
-        },
-        "examples": [{
-          "title": "Error-Response: ",
-          "content": "{\"message\": \"Account already exists\", \"data\": {}}",
-          "type": "object"
-        }]
-      },
-      "filename": "routes/api/account.js",
-      "groupTitle": "Account",
-      "sampleRequest": [{
-        "url": "https://mchacks.ca/api/account/"
-      }]
-    },
-    {
-      "type": "get",
-      "url": "/account/:id",
-      "title": "gets information from an account with mongoid ':id'",
-      "name": "getAccount",
-      "group": "Account",
-      "version": "0.0.8",
-      "parameter": {
-        "fields": {
-          "param": [{
-            "group": "param",
-            "type": "ObjectId",
-            "optional": false,
-            "field": "id",
-            "description": "<p>MongoId of an account</p>"
-          }]
-        }
-      },
-      "success": {
-        "fields": {
-          "Success 200": [{
-              "group": "Success 200",
-              "type": "string",
-              "optional": false,
-              "field": "message",
-              "description": "<p>Success message</p>"
-            },
-            {
-              "group": "Success 200",
-              "type": "object",
-              "optional": false,
-              "field": "data",
-              "description": "<p>Account object</p>"
-            }
-          ]
-        },
-        "examples": [{
-          "title": "Success-Response: ",
-          "content": "{\n               \"message\": \"Account found by user id\", \n               \"data\": {AccountObject}\n           }",
-          "type": "object"
-        }]
-      },
-      "error": {
-        "fields": {
-          "Error 4xx": [{
-              "group": "Error 4xx",
-              "type": "string",
-              "optional": false,
-              "field": "message",
-              "description": "<p>Error message</p>"
-            },
-            {
-              "group": "Error 4xx",
-              "type": "object",
-              "optional": false,
-              "field": "data",
-              "description": "<p>empty</p>"
-            }
-          ]
-        },
-        "examples": [{
-          "title": "Error-Response: ",
-          "content": "{\"message\": \"Account not found\", \"data\": {}}",
-          "type": "object"
-        }]
-      },
-      "filename": "routes/api/account.js",
-      "groupTitle": "Account",
-      "sampleRequest": [{
-        "url": "https://mchacks.ca/api/account/:id"
-      }]
-    },
-    {
-      "type": "get",
-      "url": "/account/self",
-      "title": "get information about own account",
-      "name": "self",
-      "group": "Account",
-      "version": "0.0.8",
-      "success": {
-        "fields": {
-          "Success 200": [{
-              "group": "Success 200",
-              "type": "string",
-              "optional": false,
-              "field": "message",
-              "description": "<p>Success message</p>"
-            },
-            {
-              "group": "Success 200",
-              "type": "object",
-              "optional": false,
-              "field": "data",
-              "description": "<p>Account object</p>"
-            }
-          ]
-        },
-        "examples": [{
-          "title": "Success-Response: ",
-          "content": "{\n               \"message\": \"Account found by user email\", \n               \"data\": {AccountObject}\n           }",
-          "type": "object"
-        }]
-      },
-      "error": {
-        "fields": {
-          "Error 4xx": [{
-              "group": "Error 4xx",
-              "type": "string",
-              "optional": false,
-              "field": "message",
-              "description": "<p>Error message</p>"
-            },
-            {
-              "group": "Error 4xx",
-              "type": "object",
-              "optional": false,
-              "field": "data",
-              "description": "<p>empty</p>"
-            }
-          ]
-        },
-        "examples": [{
-          "title": "Error-Response: ",
-          "content": "{\"message\": \"Account not found\", \"data\": {}}",
-          "type": "object"
-        }]
-      },
-      "filename": "routes/api/account.js",
-      "groupTitle": "Account",
-      "sampleRequest": [{
-        "url": "https://mchacks.ca/api/account/self"
-      }]
-    },
-    {
-      "type": "patch",
-      "url": "/account/:id",
-      "title": "update an account's information",
-      "name": "updateOneUser",
-      "group": "Account",
-      "version": "0.0.8",
-      "parameter": {
-        "fields": {
-          "body": [{
-              "group": "body",
-              "type": "String",
-              "optional": true,
-              "field": "firstName",
-              "description": "<p>First name of the account creator.</p>"
-            },
-            {
-              "group": "body",
-              "type": "String",
-              "optional": true,
-              "field": "lastName",
-              "description": "<p>Last name of the account creator.</p>"
-            },
-            {
-              "group": "body",
-              "type": "String",
-              "optional": true,
-              "field": "email",
-              "description": "<p>Email of the account.</p>"
-            },
-            {
-              "group": "body",
-              "type": "String",
-              "optional": true,
-              "field": "dietaryRestrictions",
-              "description": "<p>Any dietary restrictions for the user. 'None' if there are no restrictions</p>"
-            },
-            {
-              "group": "body",
-              "type": "String",
-              "optional": true,
-              "field": "shirtSize",
-              "description": "<p>Size of the shirt that the user will receive.</p>"
-            },
-            {
-              "group": "body",
-              "type": "String",
-              "optional": true,
-              "field": "passowrd",
-              "description": "<p>The password of the account.</p>"
-            }
-          ]
-        }
-      },
-      "success": {
-        "fields": {
-          "Success 200": [{
-              "group": "Success 200",
-              "type": "string",
-              "optional": false,
-              "field": "message",
-              "description": "<p>Success message</p>"
-            },
-            {
-              "group": "Success 200",
-              "type": "object",
-              "optional": false,
-              "field": "data",
-              "description": "<p>Account object</p>"
-            }
-          ]
-        },
-        "examples": [{
-          "title": "Success-Response: ",
-          "content": "{\n               \"message\": \"Changed account information\", \n               \"data\": {...}\n           }",
-          "type": "object"
-        }]
-      },
-      "error": {
-        "fields": {
-          "Error 4xx": [{
-              "group": "Error 4xx",
-              "type": "string",
-              "optional": false,
-              "field": "message",
-              "description": "<p>Error message</p>"
-            },
-            {
-              "group": "Error 4xx",
-              "type": "object",
-              "optional": false,
-              "field": "data",
-              "description": "<p>empty</p>"
-            }
-          ]
-        },
-        "examples": [{
-          "title": "Error-Response: ",
-          "content": "{\"message\": \"Error while updating account\", \"data\": {}}",
-          "type": "object"
-        }]
-      },
-      "filename": "routes/api/account.js",
-      "groupTitle": "Account",
-      "sampleRequest": [{
-        "url": "https://mchacks.ca/api/account/:id"
-      }]
-    },
-    {
-      "type": "post",
-      "url": "/auth/confirm/:token",
-      "title": "confirm account using the JWT in :token",
-      "name": "confirmAccount",
-      "group": "Authentication",
-      "version": "0.0.8",
-      "parameter": {
-        "fields": {
-          "Parameter": [{
-            "group": "Parameter",
-            "type": "String",
-            "optional": false,
-            "field": "JWT",
-            "description": "<p>for confirming the account</p>"
-          }]
-        }
-      },
-      "success": {
-        "fields": {
-          "Success 200": [{
-              "group": "Success 200",
-              "type": "string",
-              "optional": false,
-              "field": "message",
-              "description": "<p>Success message</p>"
-            },
-            {
-              "group": "Success 200",
-              "type": "object",
-              "optional": false,
-              "field": "data",
-              "description": "<p>empty</p>"
-            }
-          ]
-        },
-        "examples": [{
-          "title": "Success-Response:",
-          "content": "{\"message\": \"Successfully confirmed account\", \"data\": {}}",
-          "type": "json"
-        }]
-      },
-      "error": {
-        "fields": {
-          "Error 4xx": [{
-              "group": "Error 4xx",
-              "type": "string",
-              "optional": false,
-              "field": "message",
-              "description": "<p>Error message</p>"
-            },
-            {
-              "group": "Error 4xx",
-              "type": "object",
-              "optional": false,
-              "field": "data",
-              "description": "<p>empty</p>"
-            }
-          ]
-        },
-        "examples": [{
-          "title": "Error-Response: ",
-          "content": "{\"message\": \"Invalid token for confirming account, \"data\": {}}",
-          "type": "object"
-        }]
-      },
-      "filename": "routes/api/auth.js",
-      "groupTitle": "Authentication",
-      "sampleRequest": [{
-        "url": "https://mchacks.ca/api/auth/confirm/:token"
-      }]
-    },
-    {
-      "type": "post",
-      "url": "/auth/password/forgot",
-      "title": "forgot password route",
-      "name": "forgotPassword",
-      "group": "Authentication",
-      "version": "0.0.8",
-      "parameter": {
-        "fields": {
-          "Parameter": [{
-            "group": "Parameter",
-            "type": "String",
-            "optional": false,
-            "field": "email",
-            "description": "<p>the email address of the account</p>"
-          }]
-        },
-        "examples": [{
-          "title": "Request-Example:",
-          "content": "{ \"email\": \"myemail@mchacks.ca\" }",
-          "type": "json"
-        }]
-      },
-      "success": {
-        "fields": {
-          "Success 200": [{
-              "group": "Success 200",
-              "type": "string",
-              "optional": false,
-              "field": "message",
-              "description": "<p>Success message</p>"
-            },
-            {
-              "group": "Success 200",
-              "type": "object",
-              "optional": false,
-              "field": "data",
-              "description": "<p>empty</p>"
-            }
-          ]
-        },
-        "examples": [{
-          "title": "Success-Response: ",
-          "content": "{\"message\": \"Sent reset email\", \"data\": {}}",
-          "type": "json"
-        }]
-      },
-      "permission": [{
-        "name": ": public"
-      }],
-      "filename": "routes/api/auth.js",
-      "groupTitle": "Authentication",
-      "sampleRequest": [{
-        "url": "https://mchacks.ca/api/auth/password/forgot"
-      }]
-    },
-    {
-      "type": "post",
-      "url": "/auth/login",
-      "title": "login to the service",
-      "name": "login",
-      "group": "Authentication",
-      "version": "0.0.8",
-      "parameter": {
-        "fields": {
-          "Parameter": [{
-              "group": "Parameter",
-              "type": "string",
-              "optional": false,
-              "field": "email",
-              "description": "<p>Account email</p>"
-            },
-            {
-              "group": "Parameter",
-              "type": "string",
-              "optional": false,
-              "field": "password",
-              "description": "<p>Account password</p>"
-            }
-          ]
-        }
-      },
-      "success": {
-        "fields": {
-          "Success 200": [{
-              "group": "Success 200",
-              "type": "string",
-              "optional": false,
-              "field": "message",
-              "description": "<p>Success message</p>"
-            },
-            {
-              "group": "Success 200",
-              "type": "object",
-              "optional": false,
-              "field": "data",
-              "description": "<p>empty</p>"
-            }
-          ]
-        },
-        "examples": [{
-          "title": "Success-Response: ",
-          "content": "{\"message\": \"Successfully logged in\", \"data\": {}}",
-          "type": "object"
-        }]
-      },
-      "error": {
-        "fields": {
-          "Error 4xx": [{
-              "group": "Error 4xx",
-              "type": "string",
-              "optional": false,
-              "field": "message",
-              "description": "<p>Error message</p>"
-            },
-            {
-              "group": "Error 4xx",
-              "type": "object",
-              "optional": false,
-              "field": "data",
-              "description": "<p>empty</p>"
-            }
-          ]
-        },
-        "examples": [{
-          "title": "Error-Response: ",
-          "content": "{\"message\": \"Invalid email or password\", \"data\": {}}",
-          "type": "object"
-        }]
-      },
-      "permission": [{
-        "name": ": public"
-      }],
-      "filename": "routes/api/auth.js",
-      "groupTitle": "Authentication",
-      "sampleRequest": [{
-        "url": "https://mchacks.ca/api/auth/login"
-      }]
-    },
-    {
-      "type": "get",
-      "url": "/auth/logout",
-      "title": "logout of service",
-      "name": "logout",
-      "group": "Authentication",
-      "version": "0.0.8",
-      "success": {
-        "fields": {
-          "Success 200": [{
-              "group": "Success 200",
-              "type": "string",
-              "optional": false,
-              "field": "message",
-              "description": "<p>Success message</p>"
-            },
-            {
-              "group": "Success 200",
-              "type": "object",
-              "optional": false,
-              "field": "data",
-              "description": "<p>empty</p>"
-            }
-          ]
-        },
-        "examples": [{
-          "title": "Success-Response: ",
-          "content": "{\"message\": \"Successfully logged out\", \"data\": {}}",
-          "type": "object"
-        }]
-      },
-      "permission": [{
-        "name": ": public"
-      }],
-      "filename": "routes/api/auth.js",
-      "groupTitle": "Authentication",
-      "sampleRequest": [{
-        "url": "https://mchacks.ca/api/auth/logout"
-      }]
-    },
-    {
-      "type": "get",
-      "url": "/auth/confirm/resend",
-      "title": "resend confirmation token",
-      "name": "resendConfirmAccount",
-      "group": "Authentication",
-      "version": "0.0.8",
-      "success": {
-        "fields": {
-          "Success 200": [{
-              "group": "Success 200",
-              "type": "string",
-              "optional": false,
-              "field": "message",
-              "description": "<p>Success message</p>"
-            },
-            {
-              "group": "Success 200",
-              "type": "object",
-              "optional": false,
-              "field": "data",
-              "description": "<p>empty</p>"
-            }
-          ]
-        },
-        "examples": [{
-          "title": "Success-Response:",
-          "content": "{\"message\": \"Successfully resent confirmation email\", \"data\": {}}",
-          "type": "json"
-        }]
-      },
-      "error": {
-        "fields": {
-          "Error 4xx": [{
-              "group": "Error 4xx",
-              "type": "string",
-              "optional": false,
-              "field": "message",
-              "description": "<p>Error message</p>"
-            },
-            {
-              "group": "Error 4xx",
-              "type": "object",
-              "optional": false,
-              "field": "data",
-              "description": "<p>empty</p>"
-            }
-          ]
-        },
-        "examples": [{
-            "title": "Error-Response:",
-            "content": " HTTP/1.1 422\n{\"message\": \"Account already confirmed, \"data\": {}}",
-            "type": "json"
-          },
-          {
-            "title": "Error-Response:",
-            "content": " HTTP/1.1 428\n{\"message\": \"Account already confirmed, \"data\": {}}",
-            "type": "json"
-          }
-        ]
-      },
-      "filename": "routes/api/auth.js",
-      "groupTitle": "Authentication",
-      "sampleRequest": [{
-        "url": "https://mchacks.ca/api/auth/confirm/resend"
-      }]
-    },
-    {
-      "type": "post",
-      "url": "/auth/password/reset",
-      "title": "reset password",
-      "name": "resetPassword",
-      "group": "Authentication",
-      "version": "0.0.8",
-      "parameter": {
-        "fields": {
-          "Parameter": [{
-            "group": "Parameter",
-            "type": "String",
-            "optional": false,
-            "field": "password",
-            "description": "<p>the password of the account</p>"
-          }]
-        },
-        "examples": [{
-          "title": "Request-Example:",
-          "content": "{ \"password\": \"hunter2\" }",
-          "type": "json"
-        }]
-      },
-      "header": {
-        "fields": {
-          "Header": [{
-            "group": "Header",
-            "type": "String",
-            "optional": false,
-            "field": "Authentication",
-            "description": "<p>the token that was provided in the reset password email</p>"
-          }]
-        },
-        "examples": [{
-          "title": "Header-Example:",
-          "content": "{\n  \"X-Reset-Token\": \"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c\"\n}",
-          "type": "json"
-        }]
-      },
-      "success": {
-        "fields": {
-          "Success 200": [{
-              "group": "Success 200",
-              "type": "string",
-              "optional": false,
-              "field": "message",
-              "description": "<p>Success message</p>"
-            },
-            {
-              "group": "Success 200",
-              "type": "object",
-              "optional": false,
-              "field": "data",
-              "description": "<p>empty</p>"
-            }
-          ]
-        },
-        "examples": [{
-          "title": "Success-Response: ",
-          "content": "{\"message\": \"Successfully reset password\", \"data\": {}}",
-          "type": "json"
-        }]
-      },
-      "permission": [{
-        "name": ": must have authentication token"
-      }],
-      "filename": "routes/api/auth.js",
-      "groupTitle": "Authentication",
-      "sampleRequest": [{
-        "url": "https://mchacks.ca/api/auth/password/reset"
-      }]
-    },
-    {
-      "type": "get",
-      "url": "/auth/rolebindings/:id",
-      "title": "retrieve rolebindings for a user given by their user id :id",
-      "name": "getRoleBindings",
-      "group": "Auth",
-      "version": "0.0.8",
-      "parameter": {
-        "fields": {
-          "param": [{
-            "group": "param",
-            "type": "ObjectId",
-            "optional": false,
-            "field": "id",
-            "description": "<p>MongoId of an account</p>"
-          }]
-        }
-      },
-      "success": {
-        "fields": {
-          "Success 200": [{
-              "group": "Success 200",
-              "type": "string",
-              "optional": false,
-              "field": "message",
-              "description": "<p>Success message</p>"
-            },
-            {
-              "group": "Success 200",
-              "type": "object",
-              "optional": false,
-              "field": "data",
-              "description": "<p>Rolebindings object</p>"
-            }
-          ]
-        },
-        "examples": [{
-          "title": "Success-Response: ",
-          "content": "{\n               \"message\": \"Successfully retrieved role bindings\",\n               \"data\": {\n                   accountId:\"5beca4ab2e069a34f91697b2\"\n                   id:\"5beca4ae2e069a34f91698b1\"\n                   roles: [\n                       {\n                           _id:\"5beca4ab2e069a34f91697d9\",\n                           name:\"hacker\",\n                           routes: [\n                               0:Object {_id: \"5beca4ae2e069a34f9169852\", requestType: \"POST\", uri: \"/api/auth/login\"},\n                               1:Object {_id: \"5beca4ae2e069a34f9169851\", requestType: \"POST\", uri: \"/api/auth/logout\"},\n                               2:Object {_id: \"5beca4ae2e069a34f9169850\", requestType: \"GET\", uri: \"/api/auth/rolebindings/:self\"},\n                               3:Object {_id: \"5beca4ae2e069a34f916984f\", requestType: \"GET\", uri: \"/api/account/self\"},\n                               4:Object {_id: \"5beca4ae2e069a34f916984e\", requestType: \"GET\", uri: \"/api/account/:self\"},\n                               5:Object {_id: \"5beca4ae2e069a34f916984d\", requestType: \"PATCH\", uri: \"/api/account/:self\"},\n                               6:Object {_id: \"5beca4ae2e069a34f916984c\", requestType: \"POST\", uri: \"/api/hacker/\"},\n                               7:Object {_id: \"5beca4ae2e069a34f916984b\", requestType: \"GET\", uri: \"/api/hacker/:self\"},\n                               8:Object {_id: \"5beca4ae2e069a34f916984a\", requestType: \"GET\", uri: \"/api/hacker/:self/resume\"},\n                               9:Object {_id: \"5beca4ae2e069a34f9169849\", requestType: \"PATCH\", uri: \"/api/hacker/:self\"}\n                           ]\n                       }\n                   ]\n               }\n           }",
-          "type": "object"
-        }]
-      },
-      "error": {
-        "fields": {
-          "Error 4xx": [{
-              "group": "Error 4xx",
-              "type": "string",
-              "optional": false,
-              "field": "message",
-              "description": "<p>Error message</p>"
-            },
-            {
-              "group": "Error 4xx",
-              "type": "object",
-              "optional": false,
-              "field": "data",
-              "description": "<p>empty</p>"
-            }
-          ]
-        },
-        "examples": [{
-          "title": "Error-Response: ",
-          "content": "{\"message\": \"Role Bindings not found\", \"data\": {}}",
-          "type": "object"
-        }]
-      },
-      "filename": "routes/api/auth.js",
-      "groupTitle": "Auth",
-      "sampleRequest": [{
-        "url": "https://mchacks.ca/api/auth/rolebindings/:id"
-      }]
-    },
-    {
-      "type": "post",
-      "url": "/hacker/",
-      "title": "create a new hacker",
-      "name": "createHacker",
-      "group": "Hacker",
-      "version": "0.0.8",
-      "parameter": {
-        "fields": {
-          "body": [{
-              "group": "body",
-              "type": "MongoID",
-              "optional": false,
-              "field": "accountId",
-              "description": "<p>ObjectID of the respective account</p>"
-            },
-            {
-              "group": "body",
-              "type": "String",
-              "optional": false,
-              "field": "school",
-              "description": "<p>Name of the school the hacker goes to</p>"
-            },
-            {
-              "group": "body",
-              "type": "String",
-              "optional": false,
-              "field": "gender",
-              "description": "<p>Gender of the hacker</p>"
-            },
-            {
-              "group": "body",
-              "type": "Boolean",
-              "optional": false,
-              "field": "needsBus",
-              "description": "<p>Whether the hacker requires a bus for transportation</p>"
-            },
-            {
-              "group": "body",
-              "type": "Json",
-              "optional": false,
-              "field": "application",
-              "description": "<p>The hacker's application. Resume and jobInterest fields are required.</p>"
-            }
-          ]
-        },
-        "examples": [{
-          "title": "application: ",
-          "content": "{\n    \"portfolioURL\": {\n        \"resume\": \"...\"\n        \"github\": \"...\",\n        \"dropler\": \"...\",\n        \"personal\": \"...\",\n        \"linkedIn\": \"...\",\n        \"other\": \"...\"\n    },\n    \"jobInterest\": \"...\",\n    \"skills\": [\"CSS\", \"HTML\"],    \n    \"comments\": \"...\",\n    \"essay\": \"...\",\n    \"team\": [id1, id2],\n}",
-          "type": "Json"
-        }]
-      },
-      "success": {
-        "fields": {
-          "Success 200": [{
-              "group": "Success 200",
-              "type": "string",
-              "optional": false,
-              "field": "message",
-              "description": "<p>Success message</p>"
-            },
-            {
-              "group": "Success 200",
-              "type": "object",
-              "optional": false,
-              "field": "data",
-              "description": "<p>Hacker object</p>"
-            }
-          ]
-        },
-        "examples": [{
-          "title": "Success-Response: ",
-          "content": "{\n    \"message\": \"Hacker creation successful\", \n    \"data\": {...}\n}",
-          "type": "object"
-        }]
-      },
-      "error": {
-        "fields": {
-          "Error 4xx": [{
-              "group": "Error 4xx",
-              "type": "string",
-              "optional": false,
-              "field": "message",
-              "description": "<p>Error message</p>"
-            },
-            {
-              "group": "Error 4xx",
-              "type": "object",
-              "optional": false,
-              "field": "data",
-              "description": "<p>empty</p>"
-            }
-          ]
-        },
-        "examples": [{
-          "title": "Error-Response: ",
-          "content": "{\"message\": \"Error while creating hacker\", \"data\": {}}",
-          "type": "object"
-        }]
-      },
-      "filename": "routes/api/hacker.js",
-      "groupTitle": "Hacker",
-      "sampleRequest": [{
-        "url": "https://mchacks.ca/api/hacker/"
-      }]
-    },
-    {
-      "type": "get",
-      "url": "/hacker/:id",
-      "title": "get a hacker's information",
-      "name": "getHacker",
-      "group": "Hacker",
-      "version": "0.0.8",
-      "parameter": {
-        "fields": {
-          "param": [{
-            "group": "param",
-            "type": "String",
-            "optional": false,
-            "field": "id",
-            "description": "<p>a hacker's unique mongoID</p>"
-          }]
-        }
-      },
-      "success": {
-        "fields": {
-          "Success 200": [{
-              "group": "Success 200",
-              "type": "String",
-              "optional": false,
-              "field": "message",
-              "description": "<p>Success message</p>"
-            },
-            {
-              "group": "Success 200",
-              "type": "Object",
-              "optional": false,
-              "field": "data",
-              "description": "<p>Sponsor object</p>"
-            }
-          ]
-        },
-        "examples": [{
-          "title": "Success-Response: ",
-          "content": "{\n               \"message\": \"Successfully retrieved hacker information\", \n               \"data\": {...}\n           }",
-          "type": "object"
-        }]
-      },
-      "error": {
-        "fields": {
-          "Error 4xx": [{
-              "group": "Error 4xx",
-              "type": "String",
-              "optional": false,
-              "field": "message",
-              "description": "<p>Error message</p>"
-            },
-            {
-              "group": "Error 4xx",
-              "type": "Object",
-              "optional": false,
-              "field": "data",
-              "description": "<p>empty</p>"
-            }
-          ]
-        },
-        "examples": [{
-          "title": "Error-Response: ",
-          "content": "{\"message\": \"Hacker not found\", \"data\": {}}",
-          "type": "object"
-        }]
-      },
-      "filename": "routes/api/hacker.js",
-      "groupTitle": "Hacker",
-      "sampleRequest": [{
-        "url": "https://mchacks.ca/api/hacker/:id"
-      }]
-    },
-    {
-      "type": "get",
-      "url": "/hacker/resume:id",
-      "title": "get the resume for a hacker.",
-      "name": "getHackerResume",
-      "group": "Hacker",
-      "version": "0.0.8",
-      "parameter": {
-        "fields": {
-          "param": [{
-            "group": "param",
-            "type": "ObjectId",
-            "optional": false,
-            "field": "id",
-            "description": "<p>Hacker id</p>"
-          }]
-        }
-      },
-      "success": {
-        "fields": {
-          "Success 200": [{
-            "group": "Success 200",
-            "type": "String",
-            "optional": false,
-            "field": "message",
-            "description": "<p>Success message</p>"
-          }]
-        },
-        "examples": [{
-          "title": "Success-Response:",
-          "content": "HTTP/1.1 200 OK \n{ \n    message: \"Downloaded resume\", \n    data: { \n        id: \"507f191e810c19729de860ea\", \n        resume: [Buffer] \n    } \n}",
-          "type": "json"
-        }]
-      },
-      "error": {
-        "fields": {
-          "Error 4xx": [{
-            "group": "Error 4xx",
-            "type": "String",
-            "optional": false,
-            "field": "message",
-            "description": "<p>&quot;Resume does not exist&quot;</p>"
-          }]
-        },
-        "examples": [{
-          "title": "Error-Response:",
-          "content": "HTTP/1.1 404 \n{ \n    message: \"Resume not found\", \n    data: {} \n}",
-          "type": "json"
-        }]
-      },
-      "permission": [{
-        "name": "Must be logged in, and the account id must be linked to the hacker."
-      }],
-      "filename": "routes/api/hacker.js",
-      "groupTitle": "Hacker"
-    },
-    {
-      "type": "patch",
-      "url": "/hacker/:id",
-      "title": "update a hacker's information.",
-      "description": "<p>This route only contains the ability to update a subset of a hacker's information. If you want to update a status, you must have Admin priviledges and use PATCH /hacker/status/:id.</p>",
-      "name": "patchHacker",
-      "group": "Hacker",
-      "version": "0.0.8",
-      "parameter": {
-        "fields": {
-          "body": [{
-              "group": "body",
-              "type": "String",
-              "optional": true,
-              "field": "school",
-              "description": "<p>Name of the school the hacker goes to</p>"
-            },
-            {
-              "group": "body",
-              "type": "String",
-              "optional": true,
-              "field": "gender",
-              "description": "<p>Gender of the hacker</p>"
-            },
-            {
-              "group": "body",
-              "type": "Boolean",
-              "optional": true,
-              "field": "needsBus",
-              "description": "<p>Whether the hacker requires a bus for transportation</p>"
-            },
-            {
-              "group": "body",
-              "type": "Json",
-              "optional": true,
-              "field": "application",
-              "description": "<p>The hacker's application</p>"
-            }
-          ]
-        },
-        "examples": [{
-          "title": "application: ",
-          "content": "{\n    \"portfolioURL\": {\n        \"resume\": \"...\"\n        \"github\": \"...\",\n        \"dropler\": \"...\",\n        \"personal\": \"...\",\n        \"linkedIn\": \"...\",\n        \"other\": \"...\"\n    },\n    \"jobInterest\": \"...\",\n    \"skills\": [\"CSS\", \"HTML\"],    \n    \"comments\": \"...\",\n    \"essay\": \"...\",\n    \"team\": [id1, id2],\n}",
-          "type": "Json"
-        }]
-      },
-      "success": {
-        "fields": {
-          "Success 200": [{
-              "group": "Success 200",
-              "type": "string",
-              "optional": false,
-              "field": "message",
-              "description": "<p>Success message</p>"
-            },
-            {
-              "group": "Success 200",
-              "type": "object",
-              "optional": false,
-              "field": "data",
-              "description": "<p>Hacker object</p>"
-            }
-          ]
-        },
-        "examples": [{
-          "title": "Success-Response: ",
-          "content": "{\n    \"message\": \"Changed hacker information\", \n    \"data\": {...}\n}",
-          "type": "object"
-        }]
-      },
-      "error": {
-        "fields": {
-          "Error 4xx": [{
-              "group": "Error 4xx",
-              "type": "string",
-              "optional": false,
-              "field": "message",
-              "description": "<p>Error message</p>"
-            },
-            {
-              "group": "Error 4xx",
-              "type": "object",
-              "optional": false,
-              "field": "data",
-              "description": "<p>empty</p>"
-            }
-          ]
-        },
-        "examples": [{
-          "title": "Error-Response: ",
-          "content": "{\"message\": \"Error while updating hacker\", \"data\": {}}",
-          "type": "object"
-        }]
-      },
-      "filename": "routes/api/hacker.js",
-      "groupTitle": "Hacker",
-      "sampleRequest": [{
-        "url": "https://mchacks.ca/api/hacker/:id"
-      }]
-    },
-    {
-      "type": "patch",
-      "url": "/hacker/status/:id",
-      "title": "update a hacker's status",
-      "name": "patchHackerStatus",
-      "group": "Hacker",
-      "version": "0.0.9",
-      "parameter": {
-        "fields": {
-          "body": [{
-            "group": "body",
-            "type": "String",
-            "optional": true,
-            "field": "status",
-            "description": "<p>Status of the hacker's application</p>"
-          }]
-        }
-      },
-      "success": {
-        "fields": {
-          "Success 200": [{
-              "group": "Success 200",
-              "type": "string",
-              "optional": false,
-              "field": "message",
-              "description": "<p>Success message</p>"
-            },
-            {
-              "group": "Success 200",
-              "type": "object",
-              "optional": false,
-              "field": "data",
-              "description": "<p>Hacker object</p>"
-            }
-          ]
-        },
-        "examples": [{
-          "title": "Success-Response: ",
-          "content": "{\n    \"message\": \"Changed hacker information\", \n    \"data\": {\n        \"status\": \"accepted\"\n    }\n}",
-          "type": "object"
-        }]
-      },
-      "permission": [{
-        "name": "Administrator"
-      }],
-      "filename": "routes/api/hacker.js",
-      "groupTitle": "Hacker",
-      "sampleRequest": [{
-        "url": "https://mchacks.ca/api/hacker/status/:id"
-      }]
-    },
-    {
-      "type": "post",
-      "url": "/hacker/resume/:id",
-      "title": "upload or update resume for a hacker.",
-      "name": "postHackerResume",
-      "group": "Hacker",
-      "version": "0.0.8",
-      "description": "<p><b>NOTE: This must be sent via multipart/form-data POST request</b></p>",
-      "parameter": {
-        "fields": {
-          "param": [{
-            "group": "param",
-            "type": "ObjectId",
-            "optional": false,
-            "field": "id",
-            "description": "<p>Hacker id</p>"
-          }],
-          "body": [{
-            "group": "body",
-            "type": "File",
-            "optional": false,
-            "field": "resume",
-            "description": "<p>The uploaded file.</p>"
-          }]
-        }
-      },
-      "success": {
-        "fields": {
-          "Success 200": [{
-              "group": "Success 200",
-              "type": "String",
-              "optional": false,
-              "field": "message",
-              "description": "<p>Success message</p>"
-            },
-            {
-              "group": "Success 200",
-              "type": "Object",
-              "optional": false,
-              "field": "data",
-              "description": "<p>Location in the bucket that the file was stored.</p>"
-            }
-          ]
-        },
-        "examples": [{
-          "title": "Success-Response: ",
-          "content": "HTTP/1.1 200 OK\n{\n    message: \"Uploaded resume\", \n    data: {\n        filename: \"resumes/1535032624768-507f191e810c19729de860ea\"\n    }\n}",
-          "type": "json"
-        }]
-      },
-      "permission": [{
-        "name": "Must be logged in, and the account id must be linked to the hacker."
-      }],
-      "filename": "routes/api/hacker.js",
-      "groupTitle": "Hacker",
-      "sampleRequest": [{
-        "url": "https://mchacks.ca/api/hacker/resume/:id"
-      }]
-    },
-    {
-      "type": "get",
-      "url": "/",
-      "title": "version",
-      "version": "0.0.8",
-      "name": "index",
-      "group": "Index",
-      "permission": [{
-        "name": "public"
-      }],
-      "filename": "routes/index.js",
-      "groupTitle": "Index",
-      "sampleRequest": [{
-        "url": "https://mchacks.ca/api/"
-      }]
-    },
-    {
-      "type": "get",
-      "url": "/search/:model",
-      "title": "provide a specific query for any defined model",
-      "name": "search",
-      "group": "Search",
-      "version": "0.0.8",
-      "parameter": {
-        "fields": {
-          "param": [{
-            "group": "param",
-            "type": "String",
-            "optional": false,
-            "field": "model",
-            "description": "<p>the model to be searched</p>"
-          }],
-          "query": [{
-            "group": "query",
-            "type": "Array",
-            "optional": false,
-            "field": "q",
-            "description": "<p>the query to be executed. For more information on how to format this, please see https://hackerapi.mchacks.ca/architecture/</p>"
-          }]
-        }
-      },
-      "success": {
-        "fields": {
-          "Success 200": [{
-              "group": "Success 200",
-              "type": "String",
-              "optional": false,
-              "field": "message",
-              "description": "<p>Success message</p>"
-            },
-            {
-              "group": "Success 200",
-              "type": "Object",
-              "optional": false,
-              "field": "data",
-              "description": "<p>Results</p>"
-            }
-          ]
-        },
-        "examples": [{
-            "title": "Success-Response:",
-            "content": "{\n               \"message\": \"Successfully executed query, returning all results\",\n               \"data\": [\n                   {...}\n               ]\n           }",
-            "type": "object"
-          },
-          {
-            "title": "Success-Response:",
-            "content": "{\n               \"message\": \"No results found.\",\n               \"data\": {}\n           }",
-            "type": "object"
-          }
-        ]
-      },
-      "error": {
-        "fields": {
-          "Error 4xx": [{
-              "group": "Error 4xx",
-              "type": "String",
-              "optional": false,
-              "field": "message",
-              "description": "<p>Error message</p>"
-            },
-            {
-              "group": "Error 4xx",
-              "type": "Object",
-              "optional": false,
-              "field": "data",
-              "description": "<p>empty</p>"
-            }
-          ]
-        },
-        "examples": [{
-          "title": "Error-Response:",
-          "content": "{\"message\": \"Validation failed\", \"data\": {}}",
-          "type": "object"
-        }]
-      },
-      "filename": "routes/api/search.js",
-      "groupTitle": "Search",
-      "sampleRequest": [{
-        "url": "https://mchacks.ca/api/search/:model"
-      }]
-    },
-    {
-      "type": "post",
-      "url": "/sponsor/",
-      "title": "create a new sponsor",
-      "name": "createSponsor",
-      "group": "Sponsor",
-      "version": "0.0.8",
-      "parameter": {
-        "fields": {
-          "body": [{
-              "group": "body",
-              "type": "MongoID",
-              "optional": false,
-              "field": "accountId",
-              "description": "<p>ObjectID of the respective account.</p>"
-            },
-            {
-              "group": "body",
-              "type": "Number",
-              "optional": false,
-              "field": "tier",
-              "description": "<p>Tier of the sponsor, from 0 to 5. 0 is lowest tier, and 5 is the custom tier.</p>"
-            },
-            {
-              "group": "body",
-              "type": "String",
-              "optional": false,
-              "field": "company",
-              "description": "<p>Name of the company.</p>"
-            },
-            {
-              "group": "body",
-              "type": "String",
-              "optional": false,
-              "field": "contractURL",
-              "description": "<p>URL link to the contract with the company.</p>"
-            },
-            {
-              "group": "body",
-              "type": "MongoID[]",
-              "optional": false,
-              "field": "nominees",
-              "description": "<p>Array of accounts that the company wish to nominate as hackers.</p>"
-            }
-          ]
-        }
-      },
-      "success": {
-        "fields": {
-          "Success 200": [{
-              "group": "Success 200",
-              "type": "String",
-              "optional": false,
-              "field": "message",
-              "description": "<p>Success message</p>"
-            },
-            {
-              "group": "Success 200",
-              "type": "Object",
-              "optional": false,
-              "field": "data",
-              "description": "<p>Sponsor object</p>"
-            }
-          ]
-        },
-        "examples": [{
-          "title": "Success-Response: ",
-          "content": "{\n               \"message\": \"Sponsor creation successful\", \n               \"data\": {...}\n           }",
-          "type": "object"
-        }]
-      },
-      "error": {
-        "fields": {
-          "Error 4xx": [{
-              "group": "Error 4xx",
-              "type": "String",
-              "optional": false,
-              "field": "message",
-              "description": "<p>Error message</p>"
-            },
-            {
-              "group": "Error 4xx",
-              "type": "Object",
-              "optional": false,
-              "field": "data",
-              "description": "<p>empty</p>"
-            }
-          ]
-        },
-        "examples": [{
-          "title": "Error-Response: ",
-          "content": "{\"message\": \"Error while creating sponsor\", \"data\": {}}",
-          "type": "object"
-        }]
-      },
-      "filename": "routes/api/sponsor.js",
-      "groupTitle": "Sponsor",
-      "sampleRequest": [{
-        "url": "https://mchacks.ca/api/sponsor/"
-      }]
-    },
-    {
-      "type": "get",
-      "url": "/sponsor/:id",
-      "title": "get a sponsor's information",
-      "name": "getSponsor",
-      "group": "Sponsor",
-      "version": "0.0.8",
-      "parameter": {
-        "fields": {
-          "param": [{
-            "group": "param",
-            "type": "string",
-            "optional": false,
-            "field": "id",
-            "description": "<p>a sponsor's unique mongoID</p>"
-          }]
-        }
-      },
-      "success": {
-        "fields": {
-          "Success 200": [{
-              "group": "Success 200",
-              "type": "String",
-              "optional": false,
-              "field": "message",
-              "description": "<p>Success message</p>"
-            },
-            {
-              "group": "Success 200",
-              "type": "Object",
-              "optional": false,
-              "field": "data",
-              "description": "<p>Sponsor object</p>"
-            }
-          ]
-        },
-        "examples": [{
-          "title": "Success-Response: ",
-          "content": "{\n               \"message\": \"Successfully retrieved sponsor information\", \n               \"data\": {...}\n           }",
-          "type": "object"
-        }]
-      },
-      "error": {
-        "fields": {
-          "Error 4xx": [{
-              "group": "Error 4xx",
-              "type": "String",
-              "optional": false,
-              "field": "message",
-              "description": "<p>Error message</p>"
-            },
-            {
-              "group": "Error 4xx",
-              "type": "Object",
-              "optional": false,
-              "field": "data",
-              "description": "<p>empty</p>"
-            }
-          ]
-        },
-        "examples": [{
-          "title": "Error-Response: ",
-          "content": "{\"message\": \"Sponsor not found\", \"data\": {}}",
-          "type": "object"
-        }]
-      },
-      "filename": "routes/api/sponsor.js",
-      "groupTitle": "Sponsor",
-      "sampleRequest": [{
-        "url": "https://mchacks.ca/api/sponsor/:id"
-      }]
-    },
-    {
-      "type": "post",
-      "url": "/team/",
-      "title": "create a new team",
-      "name": "createTeam",
-      "group": "Team",
-      "version": "0.0.8",
-      "parameter": {
-        "fields": {
-          "body": [{
-              "group": "body",
-              "type": "String",
-              "optional": false,
-              "field": "name",
-              "description": "<p>Name of the team.</p>"
-            },
-            {
-              "group": "body",
-              "type": "MongoID[]",
-              "optional": true,
-              "field": "members",
-              "description": "<p>Array of members in team.</p>"
-            },
-            {
-              "group": "body",
-              "type": "String",
-              "optional": true,
-              "field": "devpostURL",
-              "description": "<p>Devpost link to hack. Once the link is sent, the hack will be considered to be submitted.</p>"
-            },
-            {
-              "group": "body",
-              "type": "String",
-              "optional": false,
-              "field": "projectName",
-              "description": "<p>Name of the team.</p>"
-            }
-          ]
-        }
-      },
-      "success": {
-        "fields": {
-          "Success 200": [{
-              "group": "Success 200",
-              "type": "string",
-              "optional": false,
-              "field": "message",
-              "description": "<p>Success message</p>"
-            },
-            {
-              "group": "Success 200",
-              "type": "object",
-              "optional": false,
-              "field": "data",
-              "description": "<p>Team object</p>"
-            }
-          ]
-        },
-        "examples": [{
-          "title": "Success-Response: ",
-          "content": "{\n               \"message\": \"Team creation successful\", \n               \"data\": {...}\n           }",
-          "type": "object"
-        }]
-      },
-      "error": {
-        "fields": {
-          "Error 4xx": [{
-              "group": "Error 4xx",
-              "type": "string",
-              "optional": false,
-              "field": "message",
-              "description": "<p>Error message</p>"
-            },
-            {
-              "group": "Error 4xx",
-              "type": "object",
-              "optional": false,
-              "field": "data",
-              "description": "<p>empty</p>"
-            }
-          ]
-        },
-        "examples": [{
-          "title": "Error-Response: ",
-          "content": "{\"message\": \"Error while creating team\", \"data\": {}}",
-          "type": "object"
-        }]
-      },
-      "filename": "routes/api/team.js",
-      "groupTitle": "Team",
-      "sampleRequest": [{
-        "url": "https://mchacks.ca/api/team/"
-      }]
-    },
-    {
-      "type": "get",
-      "url": "/team/:id",
-      "title": "get a team's information",
-      "name": "getTeam",
-      "group": "Team",
-      "version": "0.0.8",
-      "parameter": {
-        "fields": {
-          "param": [{
-            "group": "param",
-            "type": "ObjectId",
-            "optional": false,
-            "field": "id",
-            "description": "<p>a team's unique mongoId</p>"
-          }]
-        }
-      },
-      "success": {
-        "fields": {
-          "Success 200": [{
-              "group": "Success 200",
-              "type": "String",
-              "optional": false,
-              "field": "message",
-              "description": "<p>Success message</p>"
-            },
-            {
-              "group": "Success 200",
-              "type": "Object",
-              "optional": false,
-              "field": "data",
-              "description": "<p>Sponsor object</p>"
-            }
-          ]
-        },
-        "examples": [{
-          "title": "Success-Response: ",
-          "content": "{\n               \"message\": \"Successfully retrieved team information\", \n               \"data\": {...}\n           }",
-          "type": "object"
-        }]
-      },
-      "error": {
-        "fields": {
-          "Error 4xx": [{
-              "group": "Error 4xx",
-              "type": "String",
-              "optional": false,
-              "field": "message",
-              "description": "<p>Error message</p>"
-            },
-            {
-              "group": "Error 4xx",
-              "type": "Object",
-              "optional": false,
-              "field": "data",
-              "description": "<p>empty</p>"
-            }
-          ]
-        },
-        "examples": [{
-          "title": "Error-Response: ",
-          "content": "{\"message\": \"Team not found\", \"data\": {}}",
-          "type": "object"
-        }]
-      },
-      "filename": "routes/api/team.js",
-      "groupTitle": "Team",
-      "sampleRequest": [{
-        "url": "https://mchacks.ca/api/team/:id"
-      }]
-    },
-    {
-      "type": "post",
-      "url": "/volunteer/",
-      "title": "create a new volunteer",
-      "name": "createVolunteer",
-      "group": "Volunteer",
-      "version": "0.0.8",
-      "parameter": {
-        "fields": {
-          "body": [{
-            "group": "body",
-            "type": "MongoID",
-            "optional": false,
-            "field": "accountId",
-            "description": "<p>MongoID of the account of the volunteer</p>"
-          }]
-        }
-      },
-      "success": {
-        "fields": {
-          "Success 200": [{
-              "group": "Success 200",
-              "type": "string",
-              "optional": false,
-              "field": "message",
-              "description": "<p>Success message</p>"
-            },
-            {
-              "group": "Success 200",
-              "type": "object",
-              "optional": false,
-              "field": "data",
-              "description": "<p>Volunteer object</p>"
-            }
-          ]
-        },
-        "examples": [{
-          "title": "Success-Response: ",
-          "content": "{\n               \"message\": \"Volunteer creation successful\", \n               \"data\": {...}\n           }",
-          "type": "object"
-        }]
-      },
-      "error": {
-        "fields": {
-          "Error 4xx": [{
-              "group": "Error 4xx",
-              "type": "string",
-              "optional": false,
-              "field": "message",
-              "description": "<p>Error message</p>"
-            },
-            {
-              "group": "Error 4xx",
-              "type": "object",
-              "optional": false,
-              "field": "data",
-              "description": "<p>empty</p>"
-            }
-          ]
-        },
-        "examples": [{
-          "title": "Error-Response: ",
-          "content": "{\"message\": \"Error while creating volunteer\", \"data\": {}}",
-          "type": "object"
-        }]
-      },
-      "filename": "routes/api/volunteer.js",
-      "groupTitle": "Volunteer",
-      "sampleRequest": [{
-        "url": "https://mchacks.ca/api/volunteer/"
-      }]
-    }
-  ]
-});
+define({ "api": [  {    "type": "post",    "url": "/account/",    "title": "create a new account",    "name": "create",    "group": "Account",    "version": "0.0.8",    "parameter": {      "fields": {        "body": [          {            "group": "body",            "type": "String",            "optional": false,            "field": "firstName",            "description": "<p>First name of the account creator.</p>"          },          {            "group": "body",            "type": "String",            "optional": false,            "field": "lastName",            "description": "<p>Last name of the account creator.</p>"          },          {            "group": "body",            "type": "String",            "optional": false,            "field": "email",            "description": "<p>Email of the account.</p>"          },          {            "group": "body",            "type": "String",            "optional": false,            "field": "dietaryRestrictions",            "description": "<p>Any dietary restrictions for the user. 'None' if there are no restrictions</p>"          },          {            "group": "body",            "type": "String",            "optional": false,            "field": "shirtSize",            "description": "<p>Size of the shirt that the user will receive.</p>"          },          {            "group": "body",            "type": "String",            "optional": false,            "field": "passowrd",            "description": "<p>The password of the account.</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>Account object</p>"          }        ]      },      "examples": [        {          "title": "Success-Response: ",          "content": "{\n               \"message\": \"Account creation successful\", \n               \"data\": {...}\n           }",          "type": "object"        }      ]    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Error message</p>"          },          {            "group": "Error 4xx",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Error-Response: ",          "content": "{\"message\": \"Account already exists\", \"data\": {}}",          "type": "object"        }      ]    },    "filename": "routes/api/account.js",    "groupTitle": "Account",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/account/"      }    ]  },  {    "type": "get",    "url": "/account/:id",    "title": "gets information from an account with mongoid ':id'",    "name": "getAccount",    "group": "Account",    "version": "0.0.8",    "parameter": {      "fields": {        "param": [          {            "group": "param",            "type": "ObjectId",            "optional": false,            "field": "id",            "description": "<p>MongoId of an account</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>Account object</p>"          }        ]      },      "examples": [        {          "title": "Success-Response: ",          "content": "{\n               \"message\": \"Account found by user id\", \n               \"data\": {AccountObject}\n           }",          "type": "object"        }      ]    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Error message</p>"          },          {            "group": "Error 4xx",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Error-Response: ",          "content": "{\"message\": \"Account not found\", \"data\": {}}",          "type": "object"        }      ]    },    "filename": "routes/api/account.js",    "groupTitle": "Account",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/account/:id"      }    ]  },  {    "type": "get",    "url": "/account/self",    "title": "get information about own account",    "name": "self",    "group": "Account",    "version": "0.0.8",    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>Account object</p>"          }        ]      },      "examples": [        {          "title": "Success-Response: ",          "content": "{\n               \"message\": \"Account found by user email\", \n               \"data\": {AccountObject}\n           }",          "type": "object"        }      ]    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Error message</p>"          },          {            "group": "Error 4xx",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Error-Response: ",          "content": "{\"message\": \"Account not found\", \"data\": {}}",          "type": "object"        }      ]    },    "filename": "routes/api/account.js",    "groupTitle": "Account",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/account/self"      }    ]  },  {    "type": "patch",    "url": "/account/:id",    "title": "update an account's information",    "name": "updateOneUser",    "group": "Account",    "version": "0.0.8",    "parameter": {      "fields": {        "body": [          {            "group": "body",            "type": "String",            "optional": true,            "field": "firstName",            "description": "<p>First name of the account creator.</p>"          },          {            "group": "body",            "type": "String",            "optional": true,            "field": "lastName",            "description": "<p>Last name of the account creator.</p>"          },          {            "group": "body",            "type": "String",            "optional": true,            "field": "email",            "description": "<p>Email of the account.</p>"          },          {            "group": "body",            "type": "String",            "optional": true,            "field": "dietaryRestrictions",            "description": "<p>Any dietary restrictions for the user. 'None' if there are no restrictions</p>"          },          {            "group": "body",            "type": "String",            "optional": true,            "field": "shirtSize",            "description": "<p>Size of the shirt that the user will receive.</p>"          },          {            "group": "body",            "type": "String",            "optional": true,            "field": "passowrd",            "description": "<p>The password of the account.</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>Account object</p>"          }        ]      },      "examples": [        {          "title": "Success-Response: ",          "content": "{\n               \"message\": \"Changed account information\", \n               \"data\": {...}\n           }",          "type": "object"        }      ]    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Error message</p>"          },          {            "group": "Error 4xx",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Error-Response: ",          "content": "{\"message\": \"Error while updating account\", \"data\": {}}",          "type": "object"        }      ]    },    "filename": "routes/api/account.js",    "groupTitle": "Account",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/account/:id"      }    ]  },  {    "type": "post",    "url": "/auth/confirm/:token",    "title": "confirm account using the JWT in :token",    "name": "confirmAccount",    "group": "Authentication",    "version": "0.0.8",    "parameter": {      "fields": {        "Parameter": [          {            "group": "Parameter",            "type": "String",            "optional": false,            "field": "JWT",            "description": "<p>for confirming the account</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Success-Response:",          "content": "{\"message\": \"Successfully confirmed account\", \"data\": {}}",          "type": "json"        }      ]    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Error message</p>"          },          {            "group": "Error 4xx",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Error-Response: ",          "content": "{\"message\": \"Invalid token for confirming account, \"data\": {}}",          "type": "object"        }      ]    },    "filename": "routes/api/auth.js",    "groupTitle": "Authentication",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/auth/confirm/:token"      }    ]  },  {    "type": "post",    "url": "/auth/password/forgot",    "title": "forgot password route",    "name": "forgotPassword",    "group": "Authentication",    "version": "0.0.8",    "parameter": {      "fields": {        "Parameter": [          {            "group": "Parameter",            "type": "String",            "optional": false,            "field": "email",            "description": "<p>the email address of the account</p>"          }        ]      },      "examples": [        {          "title": "Request-Example:",          "content": "{ \"email\": \"myemail@mchacks.ca\" }",          "type": "json"        }      ]    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Success-Response: ",          "content": "{\"message\": \"Sent reset email\", \"data\": {}}",          "type": "json"        }      ]    },    "permission": [      {        "name": ": public"      }    ],    "filename": "routes/api/auth.js",    "groupTitle": "Authentication",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/auth/password/forgot"      }    ]  },  {    "type": "post",    "url": "/auth/login",    "title": "login to the service",    "name": "login",    "group": "Authentication",    "version": "0.0.8",    "parameter": {      "fields": {        "Parameter": [          {            "group": "Parameter",            "type": "string",            "optional": false,            "field": "email",            "description": "<p>Account email</p>"          },          {            "group": "Parameter",            "type": "string",            "optional": false,            "field": "password",            "description": "<p>Account password</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Success-Response: ",          "content": "{\"message\": \"Successfully logged in\", \"data\": {}}",          "type": "object"        }      ]    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Error message</p>"          },          {            "group": "Error 4xx",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Error-Response: ",          "content": "{\"message\": \"Invalid email or password\", \"data\": {}}",          "type": "object"        }      ]    },    "permission": [      {        "name": ": public"      }    ],    "filename": "routes/api/auth.js",    "groupTitle": "Authentication",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/auth/login"      }    ]  },  {    "type": "get",    "url": "/auth/logout",    "title": "logout of service",    "name": "logout",    "group": "Authentication",    "version": "0.0.8",    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Success-Response: ",          "content": "{\"message\": \"Successfully logged out\", \"data\": {}}",          "type": "object"        }      ]    },    "permission": [      {        "name": ": public"      }    ],    "filename": "routes/api/auth.js",    "groupTitle": "Authentication",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/auth/logout"      }    ]  },  {    "type": "get",    "url": "/auth/confirm/resend",    "title": "resend confirmation token",    "name": "resendConfirmAccount",    "group": "Authentication",    "version": "0.0.8",    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Success-Response:",          "content": "{\"message\": \"Successfully resent confirmation email\", \"data\": {}}",          "type": "json"        }      ]    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Error message</p>"          },          {            "group": "Error 4xx",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Error-Response:",          "content": " HTTP/1.1 422\n{\"message\": \"Account already confirmed, \"data\": {}}",          "type": "json"        },        {          "title": "Error-Response:",          "content": " HTTP/1.1 428\n{\"message\": \"Account already confirmed, \"data\": {}}",          "type": "json"        }      ]    },    "filename": "routes/api/auth.js",    "groupTitle": "Authentication",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/auth/confirm/resend"      }    ]  },  {    "type": "post",    "url": "/auth/password/reset",    "title": "reset password",    "name": "resetPassword",    "group": "Authentication",    "version": "0.0.8",    "parameter": {      "fields": {        "Parameter": [          {            "group": "Parameter",            "type": "String",            "optional": false,            "field": "password",            "description": "<p>the password of the account</p>"          }        ]      },      "examples": [        {          "title": "Request-Example:",          "content": "{ \"password\": \"hunter2\" }",          "type": "json"        }      ]    },    "header": {      "fields": {        "Header": [          {            "group": "Header",            "type": "String",            "optional": false,            "field": "Authentication",            "description": "<p>the token that was provided in the reset password email</p>"          }        ]      },      "examples": [        {          "title": "Header-Example:",          "content": "{\n  \"X-Reset-Token\": \"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c\"\n}",          "type": "json"        }      ]    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Success-Response: ",          "content": "{\"message\": \"Successfully reset password\", \"data\": {}}",          "type": "json"        }      ]    },    "permission": [      {        "name": ": must have authentication token"      }    ],    "filename": "routes/api/auth.js",    "groupTitle": "Authentication",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/auth/password/reset"      }    ]  },  {    "type": "get",    "url": "/auth/rolebindings/:id",    "title": "retrieve rolebindings for a user given by their user id :id",    "name": "getRoleBindings",    "group": "Auth",    "version": "0.0.8",    "parameter": {      "fields": {        "param": [          {            "group": "param",            "type": "ObjectId",            "optional": false,            "field": "id",            "description": "<p>MongoId of an account</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>Rolebindings object</p>"          }        ]      },      "examples": [        {          "title": "Success-Response: ",          "content": "{\n               \"message\": \"Successfully retrieved role bindings\",\n               \"data\": {\n                   accountId:\"5beca4ab2e069a34f91697b2\"\n                   id:\"5beca4ae2e069a34f91698b1\"\n                   roles: [\n                       {\n                           _id:\"5beca4ab2e069a34f91697d9\",\n                           name:\"hacker\",\n                           routes: [\n                               0:Object {_id: \"5beca4ae2e069a34f9169852\", requestType: \"POST\", uri: \"/api/auth/login\"},\n                               1:Object {_id: \"5beca4ae2e069a34f9169851\", requestType: \"POST\", uri: \"/api/auth/logout\"},\n                               2:Object {_id: \"5beca4ae2e069a34f9169850\", requestType: \"GET\", uri: \"/api/auth/rolebindings/:self\"},\n                               3:Object {_id: \"5beca4ae2e069a34f916984f\", requestType: \"GET\", uri: \"/api/account/self\"},\n                               4:Object {_id: \"5beca4ae2e069a34f916984e\", requestType: \"GET\", uri: \"/api/account/:self\"},\n                               5:Object {_id: \"5beca4ae2e069a34f916984d\", requestType: \"PATCH\", uri: \"/api/account/:self\"},\n                               6:Object {_id: \"5beca4ae2e069a34f916984c\", requestType: \"POST\", uri: \"/api/hacker/\"},\n                               7:Object {_id: \"5beca4ae2e069a34f916984b\", requestType: \"GET\", uri: \"/api/hacker/:self\"},\n                               8:Object {_id: \"5beca4ae2e069a34f916984a\", requestType: \"GET\", uri: \"/api/hacker/:self/resume\"},\n                               9:Object {_id: \"5beca4ae2e069a34f9169849\", requestType: \"PATCH\", uri: \"/api/hacker/:self\"}\n                           ]\n                       }\n                   ]\n               }\n           }",          "type": "object"        }      ]    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Error message</p>"          },          {            "group": "Error 4xx",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Error-Response: ",          "content": "{\"message\": \"Role Bindings not found\", \"data\": {}}",          "type": "object"        }      ]    },    "filename": "routes/api/auth.js",    "groupTitle": "Auth",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/auth/rolebindings/:id"      }    ]  },  {    "type": "post",    "url": "/hacker/",    "title": "create a new hacker",    "name": "createHacker",    "group": "Hacker",    "version": "0.0.8",    "parameter": {      "fields": {        "body": [          {            "group": "body",            "type": "MongoID",            "optional": false,            "field": "accountId",            "description": "<p>ObjectID of the respective account</p>"          },          {            "group": "body",            "type": "String",            "optional": false,            "field": "school",            "description": "<p>Name of the school the hacker goes to</p>"          },          {            "group": "body",            "type": "String",            "optional": false,            "field": "gender",            "description": "<p>Gender of the hacker</p>"          },          {            "group": "body",            "type": "Boolean",            "optional": false,            "field": "needsBus",            "description": "<p>Whether the hacker requires a bus for transportation</p>"          },          {            "group": "body",            "type": "Json",            "optional": false,            "field": "application",            "description": "<p>The hacker's application. Resume and jobInterest fields are required.</p>"          }        ]      },      "examples": [        {          "title": "application: ",          "content": "{\n    \"portfolioURL\": {\n        \"resume\": \"...\"\n        \"github\": \"...\",\n        \"dropler\": \"...\",\n        \"personal\": \"...\",\n        \"linkedIn\": \"...\",\n        \"other\": \"...\"\n    },\n    \"jobInterest\": \"...\",\n    \"skills\": [\"CSS\", \"HTML\"],    \n    \"comments\": \"...\",\n    \"essay\": \"...\",\n    \"team\": [id1, id2],\n}",          "type": "Json"        }      ]    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>Hacker object</p>"          }        ]      },      "examples": [        {          "title": "Success-Response: ",          "content": "{\n    \"message\": \"Hacker creation successful\", \n    \"data\": {...}\n}",          "type": "object"        }      ]    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Error message</p>"          },          {            "group": "Error 4xx",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Error-Response: ",          "content": "{\"message\": \"Error while creating hacker\", \"data\": {}}",          "type": "object"        }      ]    },    "filename": "routes/api/hacker.js",    "groupTitle": "Hacker",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/hacker/"      }    ]  },  {    "type": "get",    "url": "/hacker/:id",    "title": "get a hacker's information",    "name": "getHacker",    "group": "Hacker",    "version": "0.0.8",    "parameter": {      "fields": {        "param": [          {            "group": "param",            "type": "String",            "optional": false,            "field": "id",            "description": "<p>a hacker's unique mongoID</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "String",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "Object",            "optional": false,            "field": "data",            "description": "<p>Sponsor object</p>"          }        ]      },      "examples": [        {          "title": "Success-Response: ",          "content": "{\n               \"message\": \"Successfully retrieved hacker information\", \n               \"data\": {...}\n           }",          "type": "object"        }      ]    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "type": "String",            "optional": false,            "field": "message",            "description": "<p>Error message</p>"          },          {            "group": "Error 4xx",            "type": "Object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Error-Response: ",          "content": "{\"message\": \"Hacker not found\", \"data\": {}}",          "type": "object"        }      ]    },    "filename": "routes/api/hacker.js",    "groupTitle": "Hacker",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/hacker/:id"      }    ]  },  {    "type": "get",    "url": "/hacker/resume:id",    "title": "get the resume for a hacker.",    "name": "getHackerResume",    "group": "Hacker",    "version": "0.0.8",    "parameter": {      "fields": {        "param": [          {            "group": "param",            "type": "ObjectId",            "optional": false,            "field": "id",            "description": "<p>Hacker id</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "String",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          }        ]      },      "examples": [        {          "title": "Success-Response:",          "content": "HTTP/1.1 200 OK \n{ \n    message: \"Downloaded resume\", \n    data: { \n        id: \"507f191e810c19729de860ea\", \n        resume: [Buffer] \n    } \n}",          "type": "json"        }      ]    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "type": "String",            "optional": false,            "field": "message",            "description": "<p>&quot;Resume does not exist&quot;</p>"          }        ]      },      "examples": [        {          "title": "Error-Response:",          "content": "HTTP/1.1 404 \n{ \n    message: \"Resume not found\", \n    data: {} \n}",          "type": "json"        }      ]    },    "permission": [      {        "name": "Must be logged in, and the account id must be linked to the hacker."      }    ],    "filename": "routes/api/hacker.js",    "groupTitle": "Hacker"  },  {    "type": "patch",    "url": "/hacker/:id",    "title": "update a hacker's information.",    "description": "<p>This route only contains the ability to update a subset of a hacker's information. If you want to update a status, you must have Admin priviledges and use PATCH /hacker/status/:id.</p>",    "name": "patchHacker",    "group": "Hacker",    "version": "0.0.8",    "parameter": {      "fields": {        "body": [          {            "group": "body",            "type": "String",            "optional": true,            "field": "school",            "description": "<p>Name of the school the hacker goes to</p>"          },          {            "group": "body",            "type": "String",            "optional": true,            "field": "gender",            "description": "<p>Gender of the hacker</p>"          },          {            "group": "body",            "type": "Boolean",            "optional": true,            "field": "needsBus",            "description": "<p>Whether the hacker requires a bus for transportation</p>"          },          {            "group": "body",            "type": "Json",            "optional": true,            "field": "application",            "description": "<p>The hacker's application</p>"          }        ]      },      "examples": [        {          "title": "application: ",          "content": "{\n    \"portfolioURL\": {\n        \"resume\": \"...\"\n        \"github\": \"...\",\n        \"dropler\": \"...\",\n        \"personal\": \"...\",\n        \"linkedIn\": \"...\",\n        \"other\": \"...\"\n    },\n    \"jobInterest\": \"...\",\n    \"skills\": [\"CSS\", \"HTML\"],    \n    \"comments\": \"...\",\n    \"essay\": \"...\",\n    \"team\": [id1, id2],\n}",          "type": "Json"        }      ]    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>Hacker object</p>"          }        ]      },      "examples": [        {          "title": "Success-Response: ",          "content": "{\n    \"message\": \"Changed hacker information\", \n    \"data\": {...}\n}",          "type": "object"        }      ]    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Error message</p>"          },          {            "group": "Error 4xx",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Error-Response: ",          "content": "{\"message\": \"Error while updating hacker\", \"data\": {}}",          "type": "object"        }      ]    },    "filename": "routes/api/hacker.js",    "groupTitle": "Hacker",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/hacker/:id"      }    ]  },  {    "type": "patch",    "url": "/hacker/status/:id",    "title": "update a hacker's status",    "name": "patchHackerStatus",    "group": "Hacker",    "version": "0.0.9",    "parameter": {      "fields": {        "body": [          {            "group": "body",            "type": "String",            "optional": true,            "field": "status",            "description": "<p>Status of the hacker's application</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>Hacker object</p>"          }        ]      },      "examples": [        {          "title": "Success-Response: ",          "content": "{\n    \"message\": \"Changed hacker information\", \n    \"data\": {\n        \"status\": \"accepted\"\n    }\n}",          "type": "object"        }      ]    },    "permission": [      {        "name": "Administrator"      }    ],    "filename": "routes/api/hacker.js",    "groupTitle": "Hacker",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/hacker/status/:id"      }    ]  },  {    "type": "post",    "url": "/hacker/resume/:id",    "title": "upload or update resume for a hacker.",    "name": "postHackerResume",    "group": "Hacker",    "version": "0.0.8",    "description": "<p><b>NOTE: This must be sent via multipart/form-data POST request</b></p>",    "parameter": {      "fields": {        "param": [          {            "group": "param",            "type": "ObjectId",            "optional": false,            "field": "id",            "description": "<p>Hacker id</p>"          }        ],        "body": [          {            "group": "body",            "type": "File",            "optional": false,            "field": "resume",            "description": "<p>The uploaded file.</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "String",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "Object",            "optional": false,            "field": "data",            "description": "<p>Location in the bucket that the file was stored.</p>"          }        ]      },      "examples": [        {          "title": "Success-Response: ",          "content": "HTTP/1.1 200 OK\n{\n    message: \"Uploaded resume\", \n    data: {\n        filename: \"resumes/1535032624768-507f191e810c19729de860ea\"\n    }\n}",          "type": "json"        }      ]    },    "permission": [      {        "name": "Must be logged in, and the account id must be linked to the hacker."      }    ],    "filename": "routes/api/hacker.js",    "groupTitle": "Hacker",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/hacker/resume/:id"      }    ]  },  {    "type": "get",    "url": "/",    "title": "version",    "version": "0.0.8",    "name": "index",    "group": "Index",    "permission": [      {        "name": "public"      }    ],    "filename": "routes/index.js",    "groupTitle": "Index",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/"      }    ]  },  {    "type": "get",    "url": "/search/:model",    "title": "provide a specific query for any defined model",    "name": "search",    "group": "Search",    "version": "0.0.8",    "parameter": {      "fields": {        "param": [          {            "group": "param",            "type": "String",            "optional": false,            "field": "model",            "description": "<p>the model to be searched</p>"          }        ],        "query": [          {            "group": "query",            "type": "Array",            "optional": false,            "field": "q",            "description": "<p>the query to be executed. For more information on how to format this, please see https://hackerapi.mchacks.ca/architecture/</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "String",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "Object",            "optional": false,            "field": "data",            "description": "<p>Results</p>"          }        ]      },      "examples": [        {          "title": "Success-Response:",          "content": "{\n               \"message\": \"Successfully executed query, returning all results\",\n               \"data\": [\n                   {...}\n               ]\n           }",          "type": "object"        },        {          "title": "Success-Response:",          "content": "{\n               \"message\": \"No results found.\",\n               \"data\": {}\n           }",          "type": "object"        }      ]    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "type": "String",            "optional": false,            "field": "message",            "description": "<p>Error message</p>"          },          {            "group": "Error 4xx",            "type": "Object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Error-Response:",          "content": "{\"message\": \"Validation failed\", \"data\": {}}",          "type": "object"        }      ]    },    "filename": "routes/api/search.js",    "groupTitle": "Search",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/search/:model"      }    ]  },  {    "type": "post",    "url": "/sponsor/",    "title": "create a new sponsor",    "name": "createSponsor",    "group": "Sponsor",    "version": "0.0.8",    "parameter": {      "fields": {        "body": [          {            "group": "body",            "type": "MongoID",            "optional": false,            "field": "accountId",            "description": "<p>ObjectID of the respective account.</p>"          },          {            "group": "body",            "type": "Number",            "optional": false,            "field": "tier",            "description": "<p>Tier of the sponsor, from 0 to 5. 0 is lowest tier, and 5 is the custom tier.</p>"          },          {            "group": "body",            "type": "String",            "optional": false,            "field": "company",            "description": "<p>Name of the company.</p>"          },          {            "group": "body",            "type": "String",            "optional": false,            "field": "contractURL",            "description": "<p>URL link to the contract with the company.</p>"          },          {            "group": "body",            "type": "MongoID[]",            "optional": false,            "field": "nominees",            "description": "<p>Array of accounts that the company wish to nominate as hackers.</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "String",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "Object",            "optional": false,            "field": "data",            "description": "<p>Sponsor object</p>"          }        ]      },      "examples": [        {          "title": "Success-Response: ",          "content": "{\n               \"message\": \"Sponsor creation successful\", \n               \"data\": {...}\n           }",          "type": "object"        }      ]    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "type": "String",            "optional": false,            "field": "message",            "description": "<p>Error message</p>"          },          {            "group": "Error 4xx",            "type": "Object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Error-Response: ",          "content": "{\"message\": \"Error while creating sponsor\", \"data\": {}}",          "type": "object"        }      ]    },    "filename": "routes/api/sponsor.js",    "groupTitle": "Sponsor",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/sponsor/"      }    ]  },  {    "type": "get",    "url": "/sponsor/:id",    "title": "get a sponsor's information",    "name": "getSponsor",    "group": "Sponsor",    "version": "0.0.8",    "parameter": {      "fields": {        "param": [          {            "group": "param",            "type": "string",            "optional": false,            "field": "id",            "description": "<p>a sponsor's unique mongoID</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "String",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "Object",            "optional": false,            "field": "data",            "description": "<p>Sponsor object</p>"          }        ]      },      "examples": [        {          "title": "Success-Response: ",          "content": "{\n               \"message\": \"Successfully retrieved sponsor information\", \n               \"data\": {...}\n           }",          "type": "object"        }      ]    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "type": "String",            "optional": false,            "field": "message",            "description": "<p>Error message</p>"          },          {            "group": "Error 4xx",            "type": "Object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Error-Response: ",          "content": "{\"message\": \"Sponsor not found\", \"data\": {}}",          "type": "object"        }      ]    },    "filename": "routes/api/sponsor.js",    "groupTitle": "Sponsor",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/sponsor/:id"      }    ]  },  {    "type": "post",    "url": "/team/",    "title": "create a new team",    "name": "createTeam",    "group": "Team",    "version": "0.0.8",    "parameter": {      "fields": {        "body": [          {            "group": "body",            "type": "String",            "optional": false,            "field": "name",            "description": "<p>Name of the team.</p>"          },          {            "group": "body",            "type": "MongoID[]",            "optional": true,            "field": "members",            "description": "<p>Array of members in team.</p>"          },          {            "group": "body",            "type": "String",            "optional": true,            "field": "devpostURL",            "description": "<p>Devpost link to hack. Once the link is sent, the hack will be considered to be submitted.</p>"          },          {            "group": "body",            "type": "String",            "optional": false,            "field": "projectName",            "description": "<p>Name of the team.</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>Team object</p>"          }        ]      },      "examples": [        {          "title": "Success-Response: ",          "content": "{\n               \"message\": \"Team creation successful\", \n               \"data\": {...}\n           }",          "type": "object"        }      ]    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Error message</p>"          },          {            "group": "Error 4xx",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Error-Response: ",          "content": "{\"message\": \"Error while creating team\", \"data\": {}}",          "type": "object"        }      ]    },    "filename": "routes/api/team.js",    "groupTitle": "Team",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/team/"      }    ]  },  {    "type": "get",    "url": "/team/:id",    "title": "get a team's information",    "name": "getTeam",    "group": "Team",    "version": "0.0.8",    "parameter": {      "fields": {        "param": [          {            "group": "param",            "type": "ObjectId",            "optional": false,            "field": "id",            "description": "<p>a team's unique mongoId</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "String",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "Object",            "optional": false,            "field": "data",            "description": "<p>Sponsor object</p>"          }        ]      },      "examples": [        {          "title": "Success-Response: ",          "content": "{\n               \"message\": \"Successfully retrieved team information\", \n               \"data\": {...}\n           }",          "type": "object"        }      ]    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "type": "String",            "optional": false,            "field": "message",            "description": "<p>Error message</p>"          },          {            "group": "Error 4xx",            "type": "Object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Error-Response: ",          "content": "{\"message\": \"Team not found\", \"data\": {}}",          "type": "object"        }      ]    },    "filename": "routes/api/team.js",    "groupTitle": "Team",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/team/:id"      }    ]  },  {    "type": "post",    "url": "/volunteer/",    "title": "create a new volunteer",    "name": "createVolunteer",    "group": "Volunteer",    "version": "0.0.8",    "parameter": {      "fields": {        "body": [          {            "group": "body",            "type": "MongoID",            "optional": false,            "field": "accountId",            "description": "<p>MongoID of the account of the volunteer</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>Volunteer object</p>"          }        ]      },      "examples": [        {          "title": "Success-Response: ",          "content": "{\n               \"message\": \"Volunteer creation successful\", \n               \"data\": {...}\n           }",          "type": "object"        }      ]    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Error message</p>"          },          {            "group": "Error 4xx",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Error-Response: ",          "content": "{\"message\": \"Error while creating volunteer\", \"data\": {}}",          "type": "object"        }      ]    },    "filename": "routes/api/volunteer.js",    "groupTitle": "Volunteer",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/volunteer/"      }    ]  }] });

--- a/docs/api/api_data.js
+++ b/docs/api/api_data.js
@@ -546,7 +546,7 @@ define({
         },
         "examples": [{
           "title": "Error-Response: ",
-          "content": "{\"message\": \"Invalid email or password\", \"data\": {}}",
+          "content": "{\"message\": \"Invalid Authentication\", \"data\": {}}",
           "type": "object"
         }]
       },

--- a/docs/api/api_data.json
+++ b/docs/api/api_data.json
@@ -1,1768 +1,1 @@
-[{
-    "type": "post",
-    "url": "/account/",
-    "title": "create a new account",
-    "name": "create",
-    "group": "Account",
-    "version": "0.0.8",
-    "parameter": {
-      "fields": {
-        "body": [{
-            "group": "body",
-            "type": "String",
-            "optional": false,
-            "field": "firstName",
-            "description": "<p>First name of the account creator.</p>"
-          },
-          {
-            "group": "body",
-            "type": "String",
-            "optional": false,
-            "field": "lastName",
-            "description": "<p>Last name of the account creator.</p>"
-          },
-          {
-            "group": "body",
-            "type": "String",
-            "optional": false,
-            "field": "email",
-            "description": "<p>Email of the account.</p>"
-          },
-          {
-            "group": "body",
-            "type": "String",
-            "optional": false,
-            "field": "dietaryRestrictions",
-            "description": "<p>Any dietary restrictions for the user. 'None' if there are no restrictions</p>"
-          },
-          {
-            "group": "body",
-            "type": "String",
-            "optional": false,
-            "field": "shirtSize",
-            "description": "<p>Size of the shirt that the user will receive.</p>"
-          },
-          {
-            "group": "body",
-            "type": "String",
-            "optional": false,
-            "field": "passowrd",
-            "description": "<p>The password of the account.</p>"
-          }
-        ]
-      }
-    },
-    "success": {
-      "fields": {
-        "Success 200": [{
-            "group": "Success 200",
-            "type": "string",
-            "optional": false,
-            "field": "message",
-            "description": "<p>Success message</p>"
-          },
-          {
-            "group": "Success 200",
-            "type": "object",
-            "optional": false,
-            "field": "data",
-            "description": "<p>Account object</p>"
-          }
-        ]
-      },
-      "examples": [{
-        "title": "Success-Response: ",
-        "content": "{\n               \"message\": \"Account creation successful\", \n               \"data\": {...}\n           }",
-        "type": "object"
-      }]
-    },
-    "error": {
-      "fields": {
-        "Error 4xx": [{
-            "group": "Error 4xx",
-            "type": "string",
-            "optional": false,
-            "field": "message",
-            "description": "<p>Error message</p>"
-          },
-          {
-            "group": "Error 4xx",
-            "type": "object",
-            "optional": false,
-            "field": "data",
-            "description": "<p>empty</p>"
-          }
-        ]
-      },
-      "examples": [{
-        "title": "Error-Response: ",
-        "content": "{\"message\": \"Account already exists\", \"data\": {}}",
-        "type": "object"
-      }]
-    },
-    "filename": "routes/api/account.js",
-    "groupTitle": "Account",
-    "sampleRequest": [{
-      "url": "https://mchacks.ca/api/account/"
-    }]
-  },
-  {
-    "type": "get",
-    "url": "/account/:id",
-    "title": "gets information from an account with mongoid ':id'",
-    "name": "getAccount",
-    "group": "Account",
-    "version": "0.0.8",
-    "parameter": {
-      "fields": {
-        "param": [{
-          "group": "param",
-          "type": "ObjectId",
-          "optional": false,
-          "field": "id",
-          "description": "<p>MongoId of an account</p>"
-        }]
-      }
-    },
-    "success": {
-      "fields": {
-        "Success 200": [{
-            "group": "Success 200",
-            "type": "string",
-            "optional": false,
-            "field": "message",
-            "description": "<p>Success message</p>"
-          },
-          {
-            "group": "Success 200",
-            "type": "object",
-            "optional": false,
-            "field": "data",
-            "description": "<p>Account object</p>"
-          }
-        ]
-      },
-      "examples": [{
-        "title": "Success-Response: ",
-        "content": "{\n               \"message\": \"Account found by user id\", \n               \"data\": {AccountObject}\n           }",
-        "type": "object"
-      }]
-    },
-    "error": {
-      "fields": {
-        "Error 4xx": [{
-            "group": "Error 4xx",
-            "type": "string",
-            "optional": false,
-            "field": "message",
-            "description": "<p>Error message</p>"
-          },
-          {
-            "group": "Error 4xx",
-            "type": "object",
-            "optional": false,
-            "field": "data",
-            "description": "<p>empty</p>"
-          }
-        ]
-      },
-      "examples": [{
-        "title": "Error-Response: ",
-        "content": "{\"message\": \"Account not found\", \"data\": {}}",
-        "type": "object"
-      }]
-    },
-    "filename": "routes/api/account.js",
-    "groupTitle": "Account",
-    "sampleRequest": [{
-      "url": "https://mchacks.ca/api/account/:id"
-    }]
-  },
-  {
-    "type": "get",
-    "url": "/account/self",
-    "title": "get information about own account",
-    "name": "self",
-    "group": "Account",
-    "version": "0.0.8",
-    "success": {
-      "fields": {
-        "Success 200": [{
-            "group": "Success 200",
-            "type": "string",
-            "optional": false,
-            "field": "message",
-            "description": "<p>Success message</p>"
-          },
-          {
-            "group": "Success 200",
-            "type": "object",
-            "optional": false,
-            "field": "data",
-            "description": "<p>Account object</p>"
-          }
-        ]
-      },
-      "examples": [{
-        "title": "Success-Response: ",
-        "content": "{\n               \"message\": \"Account found by user email\", \n               \"data\": {AccountObject}\n           }",
-        "type": "object"
-      }]
-    },
-    "error": {
-      "fields": {
-        "Error 4xx": [{
-            "group": "Error 4xx",
-            "type": "string",
-            "optional": false,
-            "field": "message",
-            "description": "<p>Error message</p>"
-          },
-          {
-            "group": "Error 4xx",
-            "type": "object",
-            "optional": false,
-            "field": "data",
-            "description": "<p>empty</p>"
-          }
-        ]
-      },
-      "examples": [{
-        "title": "Error-Response: ",
-        "content": "{\"message\": \"Account not found\", \"data\": {}}",
-        "type": "object"
-      }]
-    },
-    "filename": "routes/api/account.js",
-    "groupTitle": "Account",
-    "sampleRequest": [{
-      "url": "https://mchacks.ca/api/account/self"
-    }]
-  },
-  {
-    "type": "patch",
-    "url": "/account/:id",
-    "title": "update an account's information",
-    "name": "updateOneUser",
-    "group": "Account",
-    "version": "0.0.8",
-    "parameter": {
-      "fields": {
-        "body": [{
-            "group": "body",
-            "type": "String",
-            "optional": true,
-            "field": "firstName",
-            "description": "<p>First name of the account creator.</p>"
-          },
-          {
-            "group": "body",
-            "type": "String",
-            "optional": true,
-            "field": "lastName",
-            "description": "<p>Last name of the account creator.</p>"
-          },
-          {
-            "group": "body",
-            "type": "String",
-            "optional": true,
-            "field": "email",
-            "description": "<p>Email of the account.</p>"
-          },
-          {
-            "group": "body",
-            "type": "String",
-            "optional": true,
-            "field": "dietaryRestrictions",
-            "description": "<p>Any dietary restrictions for the user. 'None' if there are no restrictions</p>"
-          },
-          {
-            "group": "body",
-            "type": "String",
-            "optional": true,
-            "field": "shirtSize",
-            "description": "<p>Size of the shirt that the user will receive.</p>"
-          },
-          {
-            "group": "body",
-            "type": "String",
-            "optional": true,
-            "field": "passowrd",
-            "description": "<p>The password of the account.</p>"
-          }
-        ]
-      }
-    },
-    "success": {
-      "fields": {
-        "Success 200": [{
-            "group": "Success 200",
-            "type": "string",
-            "optional": false,
-            "field": "message",
-            "description": "<p>Success message</p>"
-          },
-          {
-            "group": "Success 200",
-            "type": "object",
-            "optional": false,
-            "field": "data",
-            "description": "<p>Account object</p>"
-          }
-        ]
-      },
-      "examples": [{
-        "title": "Success-Response: ",
-        "content": "{\n               \"message\": \"Changed account information\", \n               \"data\": {...}\n           }",
-        "type": "object"
-      }]
-    },
-    "error": {
-      "fields": {
-        "Error 4xx": [{
-            "group": "Error 4xx",
-            "type": "string",
-            "optional": false,
-            "field": "message",
-            "description": "<p>Error message</p>"
-          },
-          {
-            "group": "Error 4xx",
-            "type": "object",
-            "optional": false,
-            "field": "data",
-            "description": "<p>empty</p>"
-          }
-        ]
-      },
-      "examples": [{
-        "title": "Error-Response: ",
-        "content": "{\"message\": \"Error while updating account\", \"data\": {}}",
-        "type": "object"
-      }]
-    },
-    "filename": "routes/api/account.js",
-    "groupTitle": "Account",
-    "sampleRequest": [{
-      "url": "https://mchacks.ca/api/account/:id"
-    }]
-  },
-  {
-    "type": "post",
-    "url": "/auth/confirm/:token",
-    "title": "confirm account using the JWT in :token",
-    "name": "confirmAccount",
-    "group": "Authentication",
-    "version": "0.0.8",
-    "parameter": {
-      "fields": {
-        "Parameter": [{
-          "group": "Parameter",
-          "type": "String",
-          "optional": false,
-          "field": "JWT",
-          "description": "<p>for confirming the account</p>"
-        }]
-      }
-    },
-    "success": {
-      "fields": {
-        "Success 200": [{
-            "group": "Success 200",
-            "type": "string",
-            "optional": false,
-            "field": "message",
-            "description": "<p>Success message</p>"
-          },
-          {
-            "group": "Success 200",
-            "type": "object",
-            "optional": false,
-            "field": "data",
-            "description": "<p>empty</p>"
-          }
-        ]
-      },
-      "examples": [{
-        "title": "Success-Response:",
-        "content": "{\"message\": \"Successfully confirmed account\", \"data\": {}}",
-        "type": "json"
-      }]
-    },
-    "error": {
-      "fields": {
-        "Error 4xx": [{
-            "group": "Error 4xx",
-            "type": "string",
-            "optional": false,
-            "field": "message",
-            "description": "<p>Error message</p>"
-          },
-          {
-            "group": "Error 4xx",
-            "type": "object",
-            "optional": false,
-            "field": "data",
-            "description": "<p>empty</p>"
-          }
-        ]
-      },
-      "examples": [{
-        "title": "Error-Response: ",
-        "content": "{\"message\": \"Invalid token for confirming account, \"data\": {}}",
-        "type": "object"
-      }]
-    },
-    "filename": "routes/api/auth.js",
-    "groupTitle": "Authentication",
-    "sampleRequest": [{
-      "url": "https://mchacks.ca/api/auth/confirm/:token"
-    }]
-  },
-  {
-    "type": "post",
-    "url": "/auth/password/forgot",
-    "title": "forgot password route",
-    "name": "forgotPassword",
-    "group": "Authentication",
-    "version": "0.0.8",
-    "parameter": {
-      "fields": {
-        "Parameter": [{
-          "group": "Parameter",
-          "type": "String",
-          "optional": false,
-          "field": "email",
-          "description": "<p>the email address of the account</p>"
-        }]
-      },
-      "examples": [{
-        "title": "Request-Example:",
-        "content": "{ \"email\": \"myemail@mchacks.ca\" }",
-        "type": "json"
-      }]
-    },
-    "success": {
-      "fields": {
-        "Success 200": [{
-            "group": "Success 200",
-            "type": "string",
-            "optional": false,
-            "field": "message",
-            "description": "<p>Success message</p>"
-          },
-          {
-            "group": "Success 200",
-            "type": "object",
-            "optional": false,
-            "field": "data",
-            "description": "<p>empty</p>"
-          }
-        ]
-      },
-      "examples": [{
-        "title": "Success-Response: ",
-        "content": "{\"message\": \"Sent reset email\", \"data\": {}}",
-        "type": "json"
-      }]
-    },
-    "permission": [{
-      "name": ": public"
-    }],
-    "filename": "routes/api/auth.js",
-    "groupTitle": "Authentication",
-    "sampleRequest": [{
-      "url": "https://mchacks.ca/api/auth/password/forgot"
-    }]
-  },
-  {
-    "type": "post",
-    "url": "/auth/login",
-    "title": "login to the service",
-    "name": "login",
-    "group": "Authentication",
-    "version": "0.0.8",
-    "parameter": {
-      "fields": {
-        "Parameter": [{
-            "group": "Parameter",
-            "type": "string",
-            "optional": false,
-            "field": "email",
-            "description": "<p>Account email</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "string",
-            "optional": false,
-            "field": "password",
-            "description": "<p>Account password</p>"
-          }
-        ]
-      }
-    },
-    "success": {
-      "fields": {
-        "Success 200": [{
-            "group": "Success 200",
-            "type": "string",
-            "optional": false,
-            "field": "message",
-            "description": "<p>Success message</p>"
-          },
-          {
-            "group": "Success 200",
-            "type": "object",
-            "optional": false,
-            "field": "data",
-            "description": "<p>empty</p>"
-          }
-        ]
-      },
-      "examples": [{
-        "title": "Success-Response: ",
-        "content": "{\"message\": \"Successfully logged in\", \"data\": {}}",
-        "type": "object"
-      }]
-    },
-    "error": {
-      "fields": {
-        "Error 4xx": [{
-            "group": "Error 4xx",
-            "type": "string",
-            "optional": false,
-            "field": "message",
-            "description": "<p>Error message</p>"
-          },
-          {
-            "group": "Error 4xx",
-            "type": "object",
-            "optional": false,
-            "field": "data",
-            "description": "<p>empty</p>"
-          }
-        ]
-      },
-      "examples": [{
-        "title": "Error-Response: ",
-        "content": "{\"message\": \"Invalid email or password\", \"data\": {}}",
-        "type": "object"
-      }]
-    },
-    "permission": [{
-      "name": ": public"
-    }],
-    "filename": "routes/api/auth.js",
-    "groupTitle": "Authentication",
-    "sampleRequest": [{
-      "url": "https://mchacks.ca/api/auth/login"
-    }]
-  },
-  {
-    "type": "get",
-    "url": "/auth/logout",
-    "title": "logout of service",
-    "name": "logout",
-    "group": "Authentication",
-    "version": "0.0.8",
-    "success": {
-      "fields": {
-        "Success 200": [{
-            "group": "Success 200",
-            "type": "string",
-            "optional": false,
-            "field": "message",
-            "description": "<p>Success message</p>"
-          },
-          {
-            "group": "Success 200",
-            "type": "object",
-            "optional": false,
-            "field": "data",
-            "description": "<p>empty</p>"
-          }
-        ]
-      },
-      "examples": [{
-        "title": "Success-Response: ",
-        "content": "{\"message\": \"Successfully logged out\", \"data\": {}}",
-        "type": "object"
-      }]
-    },
-    "permission": [{
-      "name": ": public"
-    }],
-    "filename": "routes/api/auth.js",
-    "groupTitle": "Authentication",
-    "sampleRequest": [{
-      "url": "https://mchacks.ca/api/auth/logout"
-    }]
-  },
-  {
-    "type": "get",
-    "url": "/auth/confirm/resend",
-    "title": "resend confirmation token",
-    "name": "resendConfirmAccount",
-    "group": "Authentication",
-    "version": "0.0.8",
-    "success": {
-      "fields": {
-        "Success 200": [{
-            "group": "Success 200",
-            "type": "string",
-            "optional": false,
-            "field": "message",
-            "description": "<p>Success message</p>"
-          },
-          {
-            "group": "Success 200",
-            "type": "object",
-            "optional": false,
-            "field": "data",
-            "description": "<p>empty</p>"
-          }
-        ]
-      },
-      "examples": [{
-        "title": "Success-Response:",
-        "content": "{\"message\": \"Successfully resent confirmation email\", \"data\": {}}",
-        "type": "json"
-      }]
-    },
-    "error": {
-      "fields": {
-        "Error 4xx": [{
-            "group": "Error 4xx",
-            "type": "string",
-            "optional": false,
-            "field": "message",
-            "description": "<p>Error message</p>"
-          },
-          {
-            "group": "Error 4xx",
-            "type": "object",
-            "optional": false,
-            "field": "data",
-            "description": "<p>empty</p>"
-          }
-        ]
-      },
-      "examples": [{
-          "title": "Error-Response:",
-          "content": " HTTP/1.1 422\n{\"message\": \"Account already confirmed, \"data\": {}}",
-          "type": "json"
-        },
-        {
-          "title": "Error-Response:",
-          "content": " HTTP/1.1 428\n{\"message\": \"Account already confirmed, \"data\": {}}",
-          "type": "json"
-        }
-      ]
-    },
-    "filename": "routes/api/auth.js",
-    "groupTitle": "Authentication",
-    "sampleRequest": [{
-      "url": "https://mchacks.ca/api/auth/confirm/resend"
-    }]
-  },
-  {
-    "type": "post",
-    "url": "/auth/password/reset",
-    "title": "reset password",
-    "name": "resetPassword",
-    "group": "Authentication",
-    "version": "0.0.8",
-    "parameter": {
-      "fields": {
-        "Parameter": [{
-          "group": "Parameter",
-          "type": "String",
-          "optional": false,
-          "field": "password",
-          "description": "<p>the password of the account</p>"
-        }]
-      },
-      "examples": [{
-        "title": "Request-Example:",
-        "content": "{ \"password\": \"hunter2\" }",
-        "type": "json"
-      }]
-    },
-    "header": {
-      "fields": {
-        "Header": [{
-          "group": "Header",
-          "type": "String",
-          "optional": false,
-          "field": "Authentication",
-          "description": "<p>the token that was provided in the reset password email</p>"
-        }]
-      },
-      "examples": [{
-        "title": "Header-Example:",
-        "content": "{\n  \"X-Reset-Token\": \"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c\"\n}",
-        "type": "json"
-      }]
-    },
-    "success": {
-      "fields": {
-        "Success 200": [{
-            "group": "Success 200",
-            "type": "string",
-            "optional": false,
-            "field": "message",
-            "description": "<p>Success message</p>"
-          },
-          {
-            "group": "Success 200",
-            "type": "object",
-            "optional": false,
-            "field": "data",
-            "description": "<p>empty</p>"
-          }
-        ]
-      },
-      "examples": [{
-        "title": "Success-Response: ",
-        "content": "{\"message\": \"Successfully reset password\", \"data\": {}}",
-        "type": "json"
-      }]
-    },
-    "permission": [{
-      "name": ": must have authentication token"
-    }],
-    "filename": "routes/api/auth.js",
-    "groupTitle": "Authentication",
-    "sampleRequest": [{
-      "url": "https://mchacks.ca/api/auth/password/reset"
-    }]
-  },
-  {
-    "type": "get",
-    "url": "/auth/rolebindings/:id",
-    "title": "retrieve rolebindings for a user given by their user id :id",
-    "name": "getRoleBindings",
-    "group": "Auth",
-    "version": "0.0.8",
-    "parameter": {
-      "fields": {
-        "param": [{
-          "group": "param",
-          "type": "ObjectId",
-          "optional": false,
-          "field": "id",
-          "description": "<p>MongoId of an account</p>"
-        }]
-      }
-    },
-    "success": {
-      "fields": {
-        "Success 200": [{
-            "group": "Success 200",
-            "type": "string",
-            "optional": false,
-            "field": "message",
-            "description": "<p>Success message</p>"
-          },
-          {
-            "group": "Success 200",
-            "type": "object",
-            "optional": false,
-            "field": "data",
-            "description": "<p>Rolebindings object</p>"
-          }
-        ]
-      },
-      "examples": [{
-        "title": "Success-Response: ",
-        "content": "{\n               \"message\": \"Successfully retrieved role bindings\",\n               \"data\": {\n                   accountId:\"5beca4ab2e069a34f91697b2\"\n                   id:\"5beca4ae2e069a34f91698b1\"\n                   roles: [\n                       {\n                           _id:\"5beca4ab2e069a34f91697d9\",\n                           name:\"hacker\",\n                           routes: [\n                               0:Object {_id: \"5beca4ae2e069a34f9169852\", requestType: \"POST\", uri: \"/api/auth/login\"},\n                               1:Object {_id: \"5beca4ae2e069a34f9169851\", requestType: \"POST\", uri: \"/api/auth/logout\"},\n                               2:Object {_id: \"5beca4ae2e069a34f9169850\", requestType: \"GET\", uri: \"/api/auth/rolebindings/:self\"},\n                               3:Object {_id: \"5beca4ae2e069a34f916984f\", requestType: \"GET\", uri: \"/api/account/self\"},\n                               4:Object {_id: \"5beca4ae2e069a34f916984e\", requestType: \"GET\", uri: \"/api/account/:self\"},\n                               5:Object {_id: \"5beca4ae2e069a34f916984d\", requestType: \"PATCH\", uri: \"/api/account/:self\"},\n                               6:Object {_id: \"5beca4ae2e069a34f916984c\", requestType: \"POST\", uri: \"/api/hacker/\"},\n                               7:Object {_id: \"5beca4ae2e069a34f916984b\", requestType: \"GET\", uri: \"/api/hacker/:self\"},\n                               8:Object {_id: \"5beca4ae2e069a34f916984a\", requestType: \"GET\", uri: \"/api/hacker/:self/resume\"},\n                               9:Object {_id: \"5beca4ae2e069a34f9169849\", requestType: \"PATCH\", uri: \"/api/hacker/:self\"}\n                           ]\n                       }\n                   ]\n               }\n           }",
-        "type": "object"
-      }]
-    },
-    "error": {
-      "fields": {
-        "Error 4xx": [{
-            "group": "Error 4xx",
-            "type": "string",
-            "optional": false,
-            "field": "message",
-            "description": "<p>Error message</p>"
-          },
-          {
-            "group": "Error 4xx",
-            "type": "object",
-            "optional": false,
-            "field": "data",
-            "description": "<p>empty</p>"
-          }
-        ]
-      },
-      "examples": [{
-        "title": "Error-Response: ",
-        "content": "{\"message\": \"Role Bindings not found\", \"data\": {}}",
-        "type": "object"
-      }]
-    },
-    "filename": "routes/api/auth.js",
-    "groupTitle": "Auth",
-    "sampleRequest": [{
-      "url": "https://mchacks.ca/api/auth/rolebindings/:id"
-    }]
-  },
-  {
-    "type": "post",
-    "url": "/hacker/",
-    "title": "create a new hacker",
-    "name": "createHacker",
-    "group": "Hacker",
-    "version": "0.0.8",
-    "parameter": {
-      "fields": {
-        "body": [{
-            "group": "body",
-            "type": "MongoID",
-            "optional": false,
-            "field": "accountId",
-            "description": "<p>ObjectID of the respective account</p>"
-          },
-          {
-            "group": "body",
-            "type": "String",
-            "optional": false,
-            "field": "school",
-            "description": "<p>Name of the school the hacker goes to</p>"
-          },
-          {
-            "group": "body",
-            "type": "String",
-            "optional": false,
-            "field": "gender",
-            "description": "<p>Gender of the hacker</p>"
-          },
-          {
-            "group": "body",
-            "type": "Boolean",
-            "optional": false,
-            "field": "needsBus",
-            "description": "<p>Whether the hacker requires a bus for transportation</p>"
-          },
-          {
-            "group": "body",
-            "type": "Json",
-            "optional": false,
-            "field": "application",
-            "description": "<p>The hacker's application. Resume and jobInterest fields are required.</p>"
-          }
-        ]
-      },
-      "examples": [{
-        "title": "application: ",
-        "content": "{\n    \"portfolioURL\": {\n        \"resume\": \"...\"\n        \"github\": \"...\",\n        \"dropler\": \"...\",\n        \"personal\": \"...\",\n        \"linkedIn\": \"...\",\n        \"other\": \"...\"\n    },\n    \"jobInterest\": \"...\",\n    \"skills\": [\"CSS\", \"HTML\"],    \n    \"comments\": \"...\",\n    \"essay\": \"...\",\n    \"team\": [id1, id2],\n}",
-        "type": "Json"
-      }]
-    },
-    "success": {
-      "fields": {
-        "Success 200": [{
-            "group": "Success 200",
-            "type": "string",
-            "optional": false,
-            "field": "message",
-            "description": "<p>Success message</p>"
-          },
-          {
-            "group": "Success 200",
-            "type": "object",
-            "optional": false,
-            "field": "data",
-            "description": "<p>Hacker object</p>"
-          }
-        ]
-      },
-      "examples": [{
-        "title": "Success-Response: ",
-        "content": "{\n    \"message\": \"Hacker creation successful\", \n    \"data\": {...}\n}",
-        "type": "object"
-      }]
-    },
-    "error": {
-      "fields": {
-        "Error 4xx": [{
-            "group": "Error 4xx",
-            "type": "string",
-            "optional": false,
-            "field": "message",
-            "description": "<p>Error message</p>"
-          },
-          {
-            "group": "Error 4xx",
-            "type": "object",
-            "optional": false,
-            "field": "data",
-            "description": "<p>empty</p>"
-          }
-        ]
-      },
-      "examples": [{
-        "title": "Error-Response: ",
-        "content": "{\"message\": \"Error while creating hacker\", \"data\": {}}",
-        "type": "object"
-      }]
-    },
-    "filename": "routes/api/hacker.js",
-    "groupTitle": "Hacker",
-    "sampleRequest": [{
-      "url": "https://mchacks.ca/api/hacker/"
-    }]
-  },
-  {
-    "type": "get",
-    "url": "/hacker/:id",
-    "title": "get a hacker's information",
-    "name": "getHacker",
-    "group": "Hacker",
-    "version": "0.0.8",
-    "parameter": {
-      "fields": {
-        "param": [{
-          "group": "param",
-          "type": "String",
-          "optional": false,
-          "field": "id",
-          "description": "<p>a hacker's unique mongoID</p>"
-        }]
-      }
-    },
-    "success": {
-      "fields": {
-        "Success 200": [{
-            "group": "Success 200",
-            "type": "String",
-            "optional": false,
-            "field": "message",
-            "description": "<p>Success message</p>"
-          },
-          {
-            "group": "Success 200",
-            "type": "Object",
-            "optional": false,
-            "field": "data",
-            "description": "<p>Sponsor object</p>"
-          }
-        ]
-      },
-      "examples": [{
-        "title": "Success-Response: ",
-        "content": "{\n               \"message\": \"Successfully retrieved hacker information\", \n               \"data\": {...}\n           }",
-        "type": "object"
-      }]
-    },
-    "error": {
-      "fields": {
-        "Error 4xx": [{
-            "group": "Error 4xx",
-            "type": "String",
-            "optional": false,
-            "field": "message",
-            "description": "<p>Error message</p>"
-          },
-          {
-            "group": "Error 4xx",
-            "type": "Object",
-            "optional": false,
-            "field": "data",
-            "description": "<p>empty</p>"
-          }
-        ]
-      },
-      "examples": [{
-        "title": "Error-Response: ",
-        "content": "{\"message\": \"Hacker not found\", \"data\": {}}",
-        "type": "object"
-      }]
-    },
-    "filename": "routes/api/hacker.js",
-    "groupTitle": "Hacker",
-    "sampleRequest": [{
-      "url": "https://mchacks.ca/api/hacker/:id"
-    }]
-  },
-  {
-    "type": "get",
-    "url": "/hacker/resume:id",
-    "title": "get the resume for a hacker.",
-    "name": "getHackerResume",
-    "group": "Hacker",
-    "version": "0.0.8",
-    "parameter": {
-      "fields": {
-        "param": [{
-          "group": "param",
-          "type": "ObjectId",
-          "optional": false,
-          "field": "id",
-          "description": "<p>Hacker id</p>"
-        }]
-      }
-    },
-    "success": {
-      "fields": {
-        "Success 200": [{
-          "group": "Success 200",
-          "type": "String",
-          "optional": false,
-          "field": "message",
-          "description": "<p>Success message</p>"
-        }]
-      },
-      "examples": [{
-        "title": "Success-Response:",
-        "content": "HTTP/1.1 200 OK \n{ \n    message: \"Downloaded resume\", \n    data: { \n        id: \"507f191e810c19729de860ea\", \n        resume: [Buffer] \n    } \n}",
-        "type": "json"
-      }]
-    },
-    "error": {
-      "fields": {
-        "Error 4xx": [{
-          "group": "Error 4xx",
-          "type": "String",
-          "optional": false,
-          "field": "message",
-          "description": "<p>&quot;Resume does not exist&quot;</p>"
-        }]
-      },
-      "examples": [{
-        "title": "Error-Response:",
-        "content": "HTTP/1.1 404 \n{ \n    message: \"Resume not found\", \n    data: {} \n}",
-        "type": "json"
-      }]
-    },
-    "permission": [{
-      "name": "Must be logged in, and the account id must be linked to the hacker."
-    }],
-    "filename": "routes/api/hacker.js",
-    "groupTitle": "Hacker"
-  },
-  {
-    "type": "patch",
-    "url": "/hacker/:id",
-    "title": "update a hacker's information.",
-    "description": "<p>This route only contains the ability to update a subset of a hacker's information. If you want to update a status, you must have Admin priviledges and use PATCH /hacker/status/:id.</p>",
-    "name": "patchHacker",
-    "group": "Hacker",
-    "version": "0.0.8",
-    "parameter": {
-      "fields": {
-        "body": [{
-            "group": "body",
-            "type": "String",
-            "optional": true,
-            "field": "school",
-            "description": "<p>Name of the school the hacker goes to</p>"
-          },
-          {
-            "group": "body",
-            "type": "String",
-            "optional": true,
-            "field": "gender",
-            "description": "<p>Gender of the hacker</p>"
-          },
-          {
-            "group": "body",
-            "type": "Boolean",
-            "optional": true,
-            "field": "needsBus",
-            "description": "<p>Whether the hacker requires a bus for transportation</p>"
-          },
-          {
-            "group": "body",
-            "type": "Json",
-            "optional": true,
-            "field": "application",
-            "description": "<p>The hacker's application</p>"
-          }
-        ]
-      },
-      "examples": [{
-        "title": "application: ",
-        "content": "{\n    \"portfolioURL\": {\n        \"resume\": \"...\"\n        \"github\": \"...\",\n        \"dropler\": \"...\",\n        \"personal\": \"...\",\n        \"linkedIn\": \"...\",\n        \"other\": \"...\"\n    },\n    \"jobInterest\": \"...\",\n    \"skills\": [\"CSS\", \"HTML\"],    \n    \"comments\": \"...\",\n    \"essay\": \"...\",\n    \"team\": [id1, id2],\n}",
-        "type": "Json"
-      }]
-    },
-    "success": {
-      "fields": {
-        "Success 200": [{
-            "group": "Success 200",
-            "type": "string",
-            "optional": false,
-            "field": "message",
-            "description": "<p>Success message</p>"
-          },
-          {
-            "group": "Success 200",
-            "type": "object",
-            "optional": false,
-            "field": "data",
-            "description": "<p>Hacker object</p>"
-          }
-        ]
-      },
-      "examples": [{
-        "title": "Success-Response: ",
-        "content": "{\n    \"message\": \"Changed hacker information\", \n    \"data\": {...}\n}",
-        "type": "object"
-      }]
-    },
-    "error": {
-      "fields": {
-        "Error 4xx": [{
-            "group": "Error 4xx",
-            "type": "string",
-            "optional": false,
-            "field": "message",
-            "description": "<p>Error message</p>"
-          },
-          {
-            "group": "Error 4xx",
-            "type": "object",
-            "optional": false,
-            "field": "data",
-            "description": "<p>empty</p>"
-          }
-        ]
-      },
-      "examples": [{
-        "title": "Error-Response: ",
-        "content": "{\"message\": \"Error while updating hacker\", \"data\": {}}",
-        "type": "object"
-      }]
-    },
-    "filename": "routes/api/hacker.js",
-    "groupTitle": "Hacker",
-    "sampleRequest": [{
-      "url": "https://mchacks.ca/api/hacker/:id"
-    }]
-  },
-  {
-    "type": "patch",
-    "url": "/hacker/status/:id",
-    "title": "update a hacker's status",
-    "name": "patchHackerStatus",
-    "group": "Hacker",
-    "version": "0.0.9",
-    "parameter": {
-      "fields": {
-        "body": [{
-          "group": "body",
-          "type": "String",
-          "optional": true,
-          "field": "status",
-          "description": "<p>Status of the hacker's application</p>"
-        }]
-      }
-    },
-    "success": {
-      "fields": {
-        "Success 200": [{
-            "group": "Success 200",
-            "type": "string",
-            "optional": false,
-            "field": "message",
-            "description": "<p>Success message</p>"
-          },
-          {
-            "group": "Success 200",
-            "type": "object",
-            "optional": false,
-            "field": "data",
-            "description": "<p>Hacker object</p>"
-          }
-        ]
-      },
-      "examples": [{
-        "title": "Success-Response: ",
-        "content": "{\n    \"message\": \"Changed hacker information\", \n    \"data\": {\n        \"status\": \"accepted\"\n    }\n}",
-        "type": "object"
-      }]
-    },
-    "permission": [{
-      "name": "Administrator"
-    }],
-    "filename": "routes/api/hacker.js",
-    "groupTitle": "Hacker",
-    "sampleRequest": [{
-      "url": "https://mchacks.ca/api/hacker/status/:id"
-    }]
-  },
-  {
-    "type": "post",
-    "url": "/hacker/resume/:id",
-    "title": "upload or update resume for a hacker.",
-    "name": "postHackerResume",
-    "group": "Hacker",
-    "version": "0.0.8",
-    "description": "<p><b>NOTE: This must be sent via multipart/form-data POST request</b></p>",
-    "parameter": {
-      "fields": {
-        "param": [{
-          "group": "param",
-          "type": "ObjectId",
-          "optional": false,
-          "field": "id",
-          "description": "<p>Hacker id</p>"
-        }],
-        "body": [{
-          "group": "body",
-          "type": "File",
-          "optional": false,
-          "field": "resume",
-          "description": "<p>The uploaded file.</p>"
-        }]
-      }
-    },
-    "success": {
-      "fields": {
-        "Success 200": [{
-            "group": "Success 200",
-            "type": "String",
-            "optional": false,
-            "field": "message",
-            "description": "<p>Success message</p>"
-          },
-          {
-            "group": "Success 200",
-            "type": "Object",
-            "optional": false,
-            "field": "data",
-            "description": "<p>Location in the bucket that the file was stored.</p>"
-          }
-        ]
-      },
-      "examples": [{
-        "title": "Success-Response: ",
-        "content": "HTTP/1.1 200 OK\n{\n    message: \"Uploaded resume\", \n    data: {\n        filename: \"resumes/1535032624768-507f191e810c19729de860ea\"\n    }\n}",
-        "type": "json"
-      }]
-    },
-    "permission": [{
-      "name": "Must be logged in, and the account id must be linked to the hacker."
-    }],
-    "filename": "routes/api/hacker.js",
-    "groupTitle": "Hacker",
-    "sampleRequest": [{
-      "url": "https://mchacks.ca/api/hacker/resume/:id"
-    }]
-  },
-  {
-    "type": "get",
-    "url": "/",
-    "title": "version",
-    "version": "0.0.8",
-    "name": "index",
-    "group": "Index",
-    "permission": [{
-      "name": "public"
-    }],
-    "filename": "routes/index.js",
-    "groupTitle": "Index",
-    "sampleRequest": [{
-      "url": "https://mchacks.ca/api/"
-    }]
-  },
-  {
-    "type": "get",
-    "url": "/search/:model",
-    "title": "provide a specific query for any defined model",
-    "name": "search",
-    "group": "Search",
-    "version": "0.0.8",
-    "parameter": {
-      "fields": {
-        "param": [{
-          "group": "param",
-          "type": "String",
-          "optional": false,
-          "field": "model",
-          "description": "<p>the model to be searched</p>"
-        }],
-        "query": [{
-          "group": "query",
-          "type": "Array",
-          "optional": false,
-          "field": "q",
-          "description": "<p>the query to be executed. For more information on how to format this, please see https://hackerapi.mchacks.ca/architecture/</p>"
-        }]
-      }
-    },
-    "success": {
-      "fields": {
-        "Success 200": [{
-            "group": "Success 200",
-            "type": "String",
-            "optional": false,
-            "field": "message",
-            "description": "<p>Success message</p>"
-          },
-          {
-            "group": "Success 200",
-            "type": "Object",
-            "optional": false,
-            "field": "data",
-            "description": "<p>Results</p>"
-          }
-        ]
-      },
-      "examples": [{
-          "title": "Success-Response:",
-          "content": "{\n               \"message\": \"Successfully executed query, returning all results\",\n               \"data\": [\n                   {...}\n               ]\n           }",
-          "type": "object"
-        },
-        {
-          "title": "Success-Response:",
-          "content": "{\n               \"message\": \"No results found.\",\n               \"data\": {}\n           }",
-          "type": "object"
-        }
-      ]
-    },
-    "error": {
-      "fields": {
-        "Error 4xx": [{
-            "group": "Error 4xx",
-            "type": "String",
-            "optional": false,
-            "field": "message",
-            "description": "<p>Error message</p>"
-          },
-          {
-            "group": "Error 4xx",
-            "type": "Object",
-            "optional": false,
-            "field": "data",
-            "description": "<p>empty</p>"
-          }
-        ]
-      },
-      "examples": [{
-        "title": "Error-Response:",
-        "content": "{\"message\": \"Validation failed\", \"data\": {}}",
-        "type": "object"
-      }]
-    },
-    "filename": "routes/api/search.js",
-    "groupTitle": "Search",
-    "sampleRequest": [{
-      "url": "https://mchacks.ca/api/search/:model"
-    }]
-  },
-  {
-    "type": "post",
-    "url": "/sponsor/",
-    "title": "create a new sponsor",
-    "name": "createSponsor",
-    "group": "Sponsor",
-    "version": "0.0.8",
-    "parameter": {
-      "fields": {
-        "body": [{
-            "group": "body",
-            "type": "MongoID",
-            "optional": false,
-            "field": "accountId",
-            "description": "<p>ObjectID of the respective account.</p>"
-          },
-          {
-            "group": "body",
-            "type": "Number",
-            "optional": false,
-            "field": "tier",
-            "description": "<p>Tier of the sponsor, from 0 to 5. 0 is lowest tier, and 5 is the custom tier.</p>"
-          },
-          {
-            "group": "body",
-            "type": "String",
-            "optional": false,
-            "field": "company",
-            "description": "<p>Name of the company.</p>"
-          },
-          {
-            "group": "body",
-            "type": "String",
-            "optional": false,
-            "field": "contractURL",
-            "description": "<p>URL link to the contract with the company.</p>"
-          },
-          {
-            "group": "body",
-            "type": "MongoID[]",
-            "optional": false,
-            "field": "nominees",
-            "description": "<p>Array of accounts that the company wish to nominate as hackers.</p>"
-          }
-        ]
-      }
-    },
-    "success": {
-      "fields": {
-        "Success 200": [{
-            "group": "Success 200",
-            "type": "String",
-            "optional": false,
-            "field": "message",
-            "description": "<p>Success message</p>"
-          },
-          {
-            "group": "Success 200",
-            "type": "Object",
-            "optional": false,
-            "field": "data",
-            "description": "<p>Sponsor object</p>"
-          }
-        ]
-      },
-      "examples": [{
-        "title": "Success-Response: ",
-        "content": "{\n               \"message\": \"Sponsor creation successful\", \n               \"data\": {...}\n           }",
-        "type": "object"
-      }]
-    },
-    "error": {
-      "fields": {
-        "Error 4xx": [{
-            "group": "Error 4xx",
-            "type": "String",
-            "optional": false,
-            "field": "message",
-            "description": "<p>Error message</p>"
-          },
-          {
-            "group": "Error 4xx",
-            "type": "Object",
-            "optional": false,
-            "field": "data",
-            "description": "<p>empty</p>"
-          }
-        ]
-      },
-      "examples": [{
-        "title": "Error-Response: ",
-        "content": "{\"message\": \"Error while creating sponsor\", \"data\": {}}",
-        "type": "object"
-      }]
-    },
-    "filename": "routes/api/sponsor.js",
-    "groupTitle": "Sponsor",
-    "sampleRequest": [{
-      "url": "https://mchacks.ca/api/sponsor/"
-    }]
-  },
-  {
-    "type": "get",
-    "url": "/sponsor/:id",
-    "title": "get a sponsor's information",
-    "name": "getSponsor",
-    "group": "Sponsor",
-    "version": "0.0.8",
-    "parameter": {
-      "fields": {
-        "param": [{
-          "group": "param",
-          "type": "string",
-          "optional": false,
-          "field": "id",
-          "description": "<p>a sponsor's unique mongoID</p>"
-        }]
-      }
-    },
-    "success": {
-      "fields": {
-        "Success 200": [{
-            "group": "Success 200",
-            "type": "String",
-            "optional": false,
-            "field": "message",
-            "description": "<p>Success message</p>"
-          },
-          {
-            "group": "Success 200",
-            "type": "Object",
-            "optional": false,
-            "field": "data",
-            "description": "<p>Sponsor object</p>"
-          }
-        ]
-      },
-      "examples": [{
-        "title": "Success-Response: ",
-        "content": "{\n               \"message\": \"Successfully retrieved sponsor information\", \n               \"data\": {...}\n           }",
-        "type": "object"
-      }]
-    },
-    "error": {
-      "fields": {
-        "Error 4xx": [{
-            "group": "Error 4xx",
-            "type": "String",
-            "optional": false,
-            "field": "message",
-            "description": "<p>Error message</p>"
-          },
-          {
-            "group": "Error 4xx",
-            "type": "Object",
-            "optional": false,
-            "field": "data",
-            "description": "<p>empty</p>"
-          }
-        ]
-      },
-      "examples": [{
-        "title": "Error-Response: ",
-        "content": "{\"message\": \"Sponsor not found\", \"data\": {}}",
-        "type": "object"
-      }]
-    },
-    "filename": "routes/api/sponsor.js",
-    "groupTitle": "Sponsor",
-    "sampleRequest": [{
-      "url": "https://mchacks.ca/api/sponsor/:id"
-    }]
-  },
-  {
-    "type": "post",
-    "url": "/team/",
-    "title": "create a new team",
-    "name": "createTeam",
-    "group": "Team",
-    "version": "0.0.8",
-    "parameter": {
-      "fields": {
-        "body": [{
-            "group": "body",
-            "type": "String",
-            "optional": false,
-            "field": "name",
-            "description": "<p>Name of the team.</p>"
-          },
-          {
-            "group": "body",
-            "type": "MongoID[]",
-            "optional": true,
-            "field": "members",
-            "description": "<p>Array of members in team.</p>"
-          },
-          {
-            "group": "body",
-            "type": "String",
-            "optional": true,
-            "field": "devpostURL",
-            "description": "<p>Devpost link to hack. Once the link is sent, the hack will be considered to be submitted.</p>"
-          },
-          {
-            "group": "body",
-            "type": "String",
-            "optional": false,
-            "field": "projectName",
-            "description": "<p>Name of the team.</p>"
-          }
-        ]
-      }
-    },
-    "success": {
-      "fields": {
-        "Success 200": [{
-            "group": "Success 200",
-            "type": "string",
-            "optional": false,
-            "field": "message",
-            "description": "<p>Success message</p>"
-          },
-          {
-            "group": "Success 200",
-            "type": "object",
-            "optional": false,
-            "field": "data",
-            "description": "<p>Team object</p>"
-          }
-        ]
-      },
-      "examples": [{
-        "title": "Success-Response: ",
-        "content": "{\n               \"message\": \"Team creation successful\", \n               \"data\": {...}\n           }",
-        "type": "object"
-      }]
-    },
-    "error": {
-      "fields": {
-        "Error 4xx": [{
-            "group": "Error 4xx",
-            "type": "string",
-            "optional": false,
-            "field": "message",
-            "description": "<p>Error message</p>"
-          },
-          {
-            "group": "Error 4xx",
-            "type": "object",
-            "optional": false,
-            "field": "data",
-            "description": "<p>empty</p>"
-          }
-        ]
-      },
-      "examples": [{
-        "title": "Error-Response: ",
-        "content": "{\"message\": \"Error while creating team\", \"data\": {}}",
-        "type": "object"
-      }]
-    },
-    "filename": "routes/api/team.js",
-    "groupTitle": "Team",
-    "sampleRequest": [{
-      "url": "https://mchacks.ca/api/team/"
-    }]
-  },
-  {
-    "type": "get",
-    "url": "/team/:id",
-    "title": "get a team's information",
-    "name": "getTeam",
-    "group": "Team",
-    "version": "0.0.8",
-    "parameter": {
-      "fields": {
-        "param": [{
-          "group": "param",
-          "type": "ObjectId",
-          "optional": false,
-          "field": "id",
-          "description": "<p>a team's unique mongoId</p>"
-        }]
-      }
-    },
-    "success": {
-      "fields": {
-        "Success 200": [{
-            "group": "Success 200",
-            "type": "String",
-            "optional": false,
-            "field": "message",
-            "description": "<p>Success message</p>"
-          },
-          {
-            "group": "Success 200",
-            "type": "Object",
-            "optional": false,
-            "field": "data",
-            "description": "<p>Sponsor object</p>"
-          }
-        ]
-      },
-      "examples": [{
-        "title": "Success-Response: ",
-        "content": "{\n               \"message\": \"Successfully retrieved team information\", \n               \"data\": {...}\n           }",
-        "type": "object"
-      }]
-    },
-    "error": {
-      "fields": {
-        "Error 4xx": [{
-            "group": "Error 4xx",
-            "type": "String",
-            "optional": false,
-            "field": "message",
-            "description": "<p>Error message</p>"
-          },
-          {
-            "group": "Error 4xx",
-            "type": "Object",
-            "optional": false,
-            "field": "data",
-            "description": "<p>empty</p>"
-          }
-        ]
-      },
-      "examples": [{
-        "title": "Error-Response: ",
-        "content": "{\"message\": \"Team not found\", \"data\": {}}",
-        "type": "object"
-      }]
-    },
-    "filename": "routes/api/team.js",
-    "groupTitle": "Team",
-    "sampleRequest": [{
-      "url": "https://mchacks.ca/api/team/:id"
-    }]
-  },
-  {
-    "type": "post",
-    "url": "/volunteer/",
-    "title": "create a new volunteer",
-    "name": "createVolunteer",
-    "group": "Volunteer",
-    "version": "0.0.8",
-    "parameter": {
-      "fields": {
-        "body": [{
-          "group": "body",
-          "type": "MongoID",
-          "optional": false,
-          "field": "accountId",
-          "description": "<p>MongoID of the account of the volunteer</p>"
-        }]
-      }
-    },
-    "success": {
-      "fields": {
-        "Success 200": [{
-            "group": "Success 200",
-            "type": "string",
-            "optional": false,
-            "field": "message",
-            "description": "<p>Success message</p>"
-          },
-          {
-            "group": "Success 200",
-            "type": "object",
-            "optional": false,
-            "field": "data",
-            "description": "<p>Volunteer object</p>"
-          }
-        ]
-      },
-      "examples": [{
-        "title": "Success-Response: ",
-        "content": "{\n               \"message\": \"Volunteer creation successful\", \n               \"data\": {...}\n           }",
-        "type": "object"
-      }]
-    },
-    "error": {
-      "fields": {
-        "Error 4xx": [{
-            "group": "Error 4xx",
-            "type": "string",
-            "optional": false,
-            "field": "message",
-            "description": "<p>Error message</p>"
-          },
-          {
-            "group": "Error 4xx",
-            "type": "object",
-            "optional": false,
-            "field": "data",
-            "description": "<p>empty</p>"
-          }
-        ]
-      },
-      "examples": [{
-        "title": "Error-Response: ",
-        "content": "{\"message\": \"Error while creating volunteer\", \"data\": {}}",
-        "type": "object"
-      }]
-    },
-    "filename": "routes/api/volunteer.js",
-    "groupTitle": "Volunteer",
-    "sampleRequest": [{
-      "url": "https://mchacks.ca/api/volunteer/"
-    }]
-  }
-]
+[  {    "type": "post",    "url": "/account/",    "title": "create a new account",    "name": "create",    "group": "Account",    "version": "0.0.8",    "parameter": {      "fields": {        "body": [          {            "group": "body",            "type": "String",            "optional": false,            "field": "firstName",            "description": "<p>First name of the account creator.</p>"          },          {            "group": "body",            "type": "String",            "optional": false,            "field": "lastName",            "description": "<p>Last name of the account creator.</p>"          },          {            "group": "body",            "type": "String",            "optional": false,            "field": "email",            "description": "<p>Email of the account.</p>"          },          {            "group": "body",            "type": "String",            "optional": false,            "field": "dietaryRestrictions",            "description": "<p>Any dietary restrictions for the user. 'None' if there are no restrictions</p>"          },          {            "group": "body",            "type": "String",            "optional": false,            "field": "shirtSize",            "description": "<p>Size of the shirt that the user will receive.</p>"          },          {            "group": "body",            "type": "String",            "optional": false,            "field": "passowrd",            "description": "<p>The password of the account.</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>Account object</p>"          }        ]      },      "examples": [        {          "title": "Success-Response: ",          "content": "{\n               \"message\": \"Account creation successful\", \n               \"data\": {...}\n           }",          "type": "object"        }      ]    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Error message</p>"          },          {            "group": "Error 4xx",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Error-Response: ",          "content": "{\"message\": \"Account already exists\", \"data\": {}}",          "type": "object"        }      ]    },    "filename": "routes/api/account.js",    "groupTitle": "Account",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/account/"      }    ]  },  {    "type": "get",    "url": "/account/:id",    "title": "gets information from an account with mongoid ':id'",    "name": "getAccount",    "group": "Account",    "version": "0.0.8",    "parameter": {      "fields": {        "param": [          {            "group": "param",            "type": "ObjectId",            "optional": false,            "field": "id",            "description": "<p>MongoId of an account</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>Account object</p>"          }        ]      },      "examples": [        {          "title": "Success-Response: ",          "content": "{\n               \"message\": \"Account found by user id\", \n               \"data\": {AccountObject}\n           }",          "type": "object"        }      ]    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Error message</p>"          },          {            "group": "Error 4xx",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Error-Response: ",          "content": "{\"message\": \"Account not found\", \"data\": {}}",          "type": "object"        }      ]    },    "filename": "routes/api/account.js",    "groupTitle": "Account",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/account/:id"      }    ]  },  {    "type": "get",    "url": "/account/self",    "title": "get information about own account",    "name": "self",    "group": "Account",    "version": "0.0.8",    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>Account object</p>"          }        ]      },      "examples": [        {          "title": "Success-Response: ",          "content": "{\n               \"message\": \"Account found by user email\", \n               \"data\": {AccountObject}\n           }",          "type": "object"        }      ]    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Error message</p>"          },          {            "group": "Error 4xx",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Error-Response: ",          "content": "{\"message\": \"Account not found\", \"data\": {}}",          "type": "object"        }      ]    },    "filename": "routes/api/account.js",    "groupTitle": "Account",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/account/self"      }    ]  },  {    "type": "patch",    "url": "/account/:id",    "title": "update an account's information",    "name": "updateOneUser",    "group": "Account",    "version": "0.0.8",    "parameter": {      "fields": {        "body": [          {            "group": "body",            "type": "String",            "optional": true,            "field": "firstName",            "description": "<p>First name of the account creator.</p>"          },          {            "group": "body",            "type": "String",            "optional": true,            "field": "lastName",            "description": "<p>Last name of the account creator.</p>"          },          {            "group": "body",            "type": "String",            "optional": true,            "field": "email",            "description": "<p>Email of the account.</p>"          },          {            "group": "body",            "type": "String",            "optional": true,            "field": "dietaryRestrictions",            "description": "<p>Any dietary restrictions for the user. 'None' if there are no restrictions</p>"          },          {            "group": "body",            "type": "String",            "optional": true,            "field": "shirtSize",            "description": "<p>Size of the shirt that the user will receive.</p>"          },          {            "group": "body",            "type": "String",            "optional": true,            "field": "passowrd",            "description": "<p>The password of the account.</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>Account object</p>"          }        ]      },      "examples": [        {          "title": "Success-Response: ",          "content": "{\n               \"message\": \"Changed account information\", \n               \"data\": {...}\n           }",          "type": "object"        }      ]    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Error message</p>"          },          {            "group": "Error 4xx",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Error-Response: ",          "content": "{\"message\": \"Error while updating account\", \"data\": {}}",          "type": "object"        }      ]    },    "filename": "routes/api/account.js",    "groupTitle": "Account",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/account/:id"      }    ]  },  {    "type": "post",    "url": "/auth/confirm/:token",    "title": "confirm account using the JWT in :token",    "name": "confirmAccount",    "group": "Authentication",    "version": "0.0.8",    "parameter": {      "fields": {        "Parameter": [          {            "group": "Parameter",            "type": "String",            "optional": false,            "field": "JWT",            "description": "<p>for confirming the account</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Success-Response:",          "content": "{\"message\": \"Successfully confirmed account\", \"data\": {}}",          "type": "json"        }      ]    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Error message</p>"          },          {            "group": "Error 4xx",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Error-Response: ",          "content": "{\"message\": \"Invalid token for confirming account, \"data\": {}}",          "type": "object"        }      ]    },    "filename": "routes/api/auth.js",    "groupTitle": "Authentication",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/auth/confirm/:token"      }    ]  },  {    "type": "post",    "url": "/auth/password/forgot",    "title": "forgot password route",    "name": "forgotPassword",    "group": "Authentication",    "version": "0.0.8",    "parameter": {      "fields": {        "Parameter": [          {            "group": "Parameter",            "type": "String",            "optional": false,            "field": "email",            "description": "<p>the email address of the account</p>"          }        ]      },      "examples": [        {          "title": "Request-Example:",          "content": "{ \"email\": \"myemail@mchacks.ca\" }",          "type": "json"        }      ]    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Success-Response: ",          "content": "{\"message\": \"Sent reset email\", \"data\": {}}",          "type": "json"        }      ]    },    "permission": [      {        "name": ": public"      }    ],    "filename": "routes/api/auth.js",    "groupTitle": "Authentication",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/auth/password/forgot"      }    ]  },  {    "type": "post",    "url": "/auth/login",    "title": "login to the service",    "name": "login",    "group": "Authentication",    "version": "0.0.8",    "parameter": {      "fields": {        "Parameter": [          {            "group": "Parameter",            "type": "string",            "optional": false,            "field": "email",            "description": "<p>Account email</p>"          },          {            "group": "Parameter",            "type": "string",            "optional": false,            "field": "password",            "description": "<p>Account password</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Success-Response: ",          "content": "{\"message\": \"Successfully logged in\", \"data\": {}}",          "type": "object"        }      ]    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Error message</p>"          },          {            "group": "Error 4xx",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Error-Response: ",          "content": "{\"message\": \"Invalid email or password\", \"data\": {}}",          "type": "object"        }      ]    },    "permission": [      {        "name": ": public"      }    ],    "filename": "routes/api/auth.js",    "groupTitle": "Authentication",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/auth/login"      }    ]  },  {    "type": "get",    "url": "/auth/logout",    "title": "logout of service",    "name": "logout",    "group": "Authentication",    "version": "0.0.8",    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Success-Response: ",          "content": "{\"message\": \"Successfully logged out\", \"data\": {}}",          "type": "object"        }      ]    },    "permission": [      {        "name": ": public"      }    ],    "filename": "routes/api/auth.js",    "groupTitle": "Authentication",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/auth/logout"      }    ]  },  {    "type": "get",    "url": "/auth/confirm/resend",    "title": "resend confirmation token",    "name": "resendConfirmAccount",    "group": "Authentication",    "version": "0.0.8",    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Success-Response:",          "content": "{\"message\": \"Successfully resent confirmation email\", \"data\": {}}",          "type": "json"        }      ]    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Error message</p>"          },          {            "group": "Error 4xx",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Error-Response:",          "content": " HTTP/1.1 422\n{\"message\": \"Account already confirmed, \"data\": {}}",          "type": "json"        },        {          "title": "Error-Response:",          "content": " HTTP/1.1 428\n{\"message\": \"Account already confirmed, \"data\": {}}",          "type": "json"        }      ]    },    "filename": "routes/api/auth.js",    "groupTitle": "Authentication",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/auth/confirm/resend"      }    ]  },  {    "type": "post",    "url": "/auth/password/reset",    "title": "reset password",    "name": "resetPassword",    "group": "Authentication",    "version": "0.0.8",    "parameter": {      "fields": {        "Parameter": [          {            "group": "Parameter",            "type": "String",            "optional": false,            "field": "password",            "description": "<p>the password of the account</p>"          }        ]      },      "examples": [        {          "title": "Request-Example:",          "content": "{ \"password\": \"hunter2\" }",          "type": "json"        }      ]    },    "header": {      "fields": {        "Header": [          {            "group": "Header",            "type": "String",            "optional": false,            "field": "Authentication",            "description": "<p>the token that was provided in the reset password email</p>"          }        ]      },      "examples": [        {          "title": "Header-Example:",          "content": "{\n  \"X-Reset-Token\": \"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c\"\n}",          "type": "json"        }      ]    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Success-Response: ",          "content": "{\"message\": \"Successfully reset password\", \"data\": {}}",          "type": "json"        }      ]    },    "permission": [      {        "name": ": must have authentication token"      }    ],    "filename": "routes/api/auth.js",    "groupTitle": "Authentication",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/auth/password/reset"      }    ]  },  {    "type": "get",    "url": "/auth/rolebindings/:id",    "title": "retrieve rolebindings for a user given by their user id :id",    "name": "getRoleBindings",    "group": "Auth",    "version": "0.0.8",    "parameter": {      "fields": {        "param": [          {            "group": "param",            "type": "ObjectId",            "optional": false,            "field": "id",            "description": "<p>MongoId of an account</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>Rolebindings object</p>"          }        ]      },      "examples": [        {          "title": "Success-Response: ",          "content": "{\n               \"message\": \"Successfully retrieved role bindings\",\n               \"data\": {\n                   accountId:\"5beca4ab2e069a34f91697b2\"\n                   id:\"5beca4ae2e069a34f91698b1\"\n                   roles: [\n                       {\n                           _id:\"5beca4ab2e069a34f91697d9\",\n                           name:\"hacker\",\n                           routes: [\n                               0:Object {_id: \"5beca4ae2e069a34f9169852\", requestType: \"POST\", uri: \"/api/auth/login\"},\n                               1:Object {_id: \"5beca4ae2e069a34f9169851\", requestType: \"POST\", uri: \"/api/auth/logout\"},\n                               2:Object {_id: \"5beca4ae2e069a34f9169850\", requestType: \"GET\", uri: \"/api/auth/rolebindings/:self\"},\n                               3:Object {_id: \"5beca4ae2e069a34f916984f\", requestType: \"GET\", uri: \"/api/account/self\"},\n                               4:Object {_id: \"5beca4ae2e069a34f916984e\", requestType: \"GET\", uri: \"/api/account/:self\"},\n                               5:Object {_id: \"5beca4ae2e069a34f916984d\", requestType: \"PATCH\", uri: \"/api/account/:self\"},\n                               6:Object {_id: \"5beca4ae2e069a34f916984c\", requestType: \"POST\", uri: \"/api/hacker/\"},\n                               7:Object {_id: \"5beca4ae2e069a34f916984b\", requestType: \"GET\", uri: \"/api/hacker/:self\"},\n                               8:Object {_id: \"5beca4ae2e069a34f916984a\", requestType: \"GET\", uri: \"/api/hacker/:self/resume\"},\n                               9:Object {_id: \"5beca4ae2e069a34f9169849\", requestType: \"PATCH\", uri: \"/api/hacker/:self\"}\n                           ]\n                       }\n                   ]\n               }\n           }",          "type": "object"        }      ]    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Error message</p>"          },          {            "group": "Error 4xx",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Error-Response: ",          "content": "{\"message\": \"Role Bindings not found\", \"data\": {}}",          "type": "object"        }      ]    },    "filename": "routes/api/auth.js",    "groupTitle": "Auth",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/auth/rolebindings/:id"      }    ]  },  {    "type": "post",    "url": "/hacker/",    "title": "create a new hacker",    "name": "createHacker",    "group": "Hacker",    "version": "0.0.8",    "parameter": {      "fields": {        "body": [          {            "group": "body",            "type": "MongoID",            "optional": false,            "field": "accountId",            "description": "<p>ObjectID of the respective account</p>"          },          {            "group": "body",            "type": "String",            "optional": false,            "field": "school",            "description": "<p>Name of the school the hacker goes to</p>"          },          {            "group": "body",            "type": "String",            "optional": false,            "field": "gender",            "description": "<p>Gender of the hacker</p>"          },          {            "group": "body",            "type": "Boolean",            "optional": false,            "field": "needsBus",            "description": "<p>Whether the hacker requires a bus for transportation</p>"          },          {            "group": "body",            "type": "Json",            "optional": false,            "field": "application",            "description": "<p>The hacker's application. Resume and jobInterest fields are required.</p>"          }        ]      },      "examples": [        {          "title": "application: ",          "content": "{\n    \"portfolioURL\": {\n        \"resume\": \"...\"\n        \"github\": \"...\",\n        \"dropler\": \"...\",\n        \"personal\": \"...\",\n        \"linkedIn\": \"...\",\n        \"other\": \"...\"\n    },\n    \"jobInterest\": \"...\",\n    \"skills\": [\"CSS\", \"HTML\"],    \n    \"comments\": \"...\",\n    \"essay\": \"...\",\n    \"team\": [id1, id2],\n}",          "type": "Json"        }      ]    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>Hacker object</p>"          }        ]      },      "examples": [        {          "title": "Success-Response: ",          "content": "{\n    \"message\": \"Hacker creation successful\", \n    \"data\": {...}\n}",          "type": "object"        }      ]    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Error message</p>"          },          {            "group": "Error 4xx",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Error-Response: ",          "content": "{\"message\": \"Error while creating hacker\", \"data\": {}}",          "type": "object"        }      ]    },    "filename": "routes/api/hacker.js",    "groupTitle": "Hacker",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/hacker/"      }    ]  },  {    "type": "get",    "url": "/hacker/:id",    "title": "get a hacker's information",    "name": "getHacker",    "group": "Hacker",    "version": "0.0.8",    "parameter": {      "fields": {        "param": [          {            "group": "param",            "type": "String",            "optional": false,            "field": "id",            "description": "<p>a hacker's unique mongoID</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "String",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "Object",            "optional": false,            "field": "data",            "description": "<p>Sponsor object</p>"          }        ]      },      "examples": [        {          "title": "Success-Response: ",          "content": "{\n               \"message\": \"Successfully retrieved hacker information\", \n               \"data\": {...}\n           }",          "type": "object"        }      ]    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "type": "String",            "optional": false,            "field": "message",            "description": "<p>Error message</p>"          },          {            "group": "Error 4xx",            "type": "Object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Error-Response: ",          "content": "{\"message\": \"Hacker not found\", \"data\": {}}",          "type": "object"        }      ]    },    "filename": "routes/api/hacker.js",    "groupTitle": "Hacker",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/hacker/:id"      }    ]  },  {    "type": "get",    "url": "/hacker/resume:id",    "title": "get the resume for a hacker.",    "name": "getHackerResume",    "group": "Hacker",    "version": "0.0.8",    "parameter": {      "fields": {        "param": [          {            "group": "param",            "type": "ObjectId",            "optional": false,            "field": "id",            "description": "<p>Hacker id</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "String",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          }        ]      },      "examples": [        {          "title": "Success-Response:",          "content": "HTTP/1.1 200 OK \n{ \n    message: \"Downloaded resume\", \n    data: { \n        id: \"507f191e810c19729de860ea\", \n        resume: [Buffer] \n    } \n}",          "type": "json"        }      ]    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "type": "String",            "optional": false,            "field": "message",            "description": "<p>&quot;Resume does not exist&quot;</p>"          }        ]      },      "examples": [        {          "title": "Error-Response:",          "content": "HTTP/1.1 404 \n{ \n    message: \"Resume not found\", \n    data: {} \n}",          "type": "json"        }      ]    },    "permission": [      {        "name": "Must be logged in, and the account id must be linked to the hacker."      }    ],    "filename": "routes/api/hacker.js",    "groupTitle": "Hacker"  },  {    "type": "patch",    "url": "/hacker/:id",    "title": "update a hacker's information.",    "description": "<p>This route only contains the ability to update a subset of a hacker's information. If you want to update a status, you must have Admin priviledges and use PATCH /hacker/status/:id.</p>",    "name": "patchHacker",    "group": "Hacker",    "version": "0.0.8",    "parameter": {      "fields": {        "body": [          {            "group": "body",            "type": "String",            "optional": true,            "field": "school",            "description": "<p>Name of the school the hacker goes to</p>"          },          {            "group": "body",            "type": "String",            "optional": true,            "field": "gender",            "description": "<p>Gender of the hacker</p>"          },          {            "group": "body",            "type": "Boolean",            "optional": true,            "field": "needsBus",            "description": "<p>Whether the hacker requires a bus for transportation</p>"          },          {            "group": "body",            "type": "Json",            "optional": true,            "field": "application",            "description": "<p>The hacker's application</p>"          }        ]      },      "examples": [        {          "title": "application: ",          "content": "{\n    \"portfolioURL\": {\n        \"resume\": \"...\"\n        \"github\": \"...\",\n        \"dropler\": \"...\",\n        \"personal\": \"...\",\n        \"linkedIn\": \"...\",\n        \"other\": \"...\"\n    },\n    \"jobInterest\": \"...\",\n    \"skills\": [\"CSS\", \"HTML\"],    \n    \"comments\": \"...\",\n    \"essay\": \"...\",\n    \"team\": [id1, id2],\n}",          "type": "Json"        }      ]    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>Hacker object</p>"          }        ]      },      "examples": [        {          "title": "Success-Response: ",          "content": "{\n    \"message\": \"Changed hacker information\", \n    \"data\": {...}\n}",          "type": "object"        }      ]    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Error message</p>"          },          {            "group": "Error 4xx",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Error-Response: ",          "content": "{\"message\": \"Error while updating hacker\", \"data\": {}}",          "type": "object"        }      ]    },    "filename": "routes/api/hacker.js",    "groupTitle": "Hacker",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/hacker/:id"      }    ]  },  {    "type": "patch",    "url": "/hacker/status/:id",    "title": "update a hacker's status",    "name": "patchHackerStatus",    "group": "Hacker",    "version": "0.0.9",    "parameter": {      "fields": {        "body": [          {            "group": "body",            "type": "String",            "optional": true,            "field": "status",            "description": "<p>Status of the hacker's application</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>Hacker object</p>"          }        ]      },      "examples": [        {          "title": "Success-Response: ",          "content": "{\n    \"message\": \"Changed hacker information\", \n    \"data\": {\n        \"status\": \"accepted\"\n    }\n}",          "type": "object"        }      ]    },    "permission": [      {        "name": "Administrator"      }    ],    "filename": "routes/api/hacker.js",    "groupTitle": "Hacker",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/hacker/status/:id"      }    ]  },  {    "type": "post",    "url": "/hacker/resume/:id",    "title": "upload or update resume for a hacker.",    "name": "postHackerResume",    "group": "Hacker",    "version": "0.0.8",    "description": "<p><b>NOTE: This must be sent via multipart/form-data POST request</b></p>",    "parameter": {      "fields": {        "param": [          {            "group": "param",            "type": "ObjectId",            "optional": false,            "field": "id",            "description": "<p>Hacker id</p>"          }        ],        "body": [          {            "group": "body",            "type": "File",            "optional": false,            "field": "resume",            "description": "<p>The uploaded file.</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "String",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "Object",            "optional": false,            "field": "data",            "description": "<p>Location in the bucket that the file was stored.</p>"          }        ]      },      "examples": [        {          "title": "Success-Response: ",          "content": "HTTP/1.1 200 OK\n{\n    message: \"Uploaded resume\", \n    data: {\n        filename: \"resumes/1535032624768-507f191e810c19729de860ea\"\n    }\n}",          "type": "json"        }      ]    },    "permission": [      {        "name": "Must be logged in, and the account id must be linked to the hacker."      }    ],    "filename": "routes/api/hacker.js",    "groupTitle": "Hacker",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/hacker/resume/:id"      }    ]  },  {    "type": "get",    "url": "/",    "title": "version",    "version": "0.0.8",    "name": "index",    "group": "Index",    "permission": [      {        "name": "public"      }    ],    "filename": "routes/index.js",    "groupTitle": "Index",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/"      }    ]  },  {    "type": "get",    "url": "/search/:model",    "title": "provide a specific query for any defined model",    "name": "search",    "group": "Search",    "version": "0.0.8",    "parameter": {      "fields": {        "param": [          {            "group": "param",            "type": "String",            "optional": false,            "field": "model",            "description": "<p>the model to be searched</p>"          }        ],        "query": [          {            "group": "query",            "type": "Array",            "optional": false,            "field": "q",            "description": "<p>the query to be executed. For more information on how to format this, please see https://hackerapi.mchacks.ca/architecture/</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "String",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "Object",            "optional": false,            "field": "data",            "description": "<p>Results</p>"          }        ]      },      "examples": [        {          "title": "Success-Response:",          "content": "{\n               \"message\": \"Successfully executed query, returning all results\",\n               \"data\": [\n                   {...}\n               ]\n           }",          "type": "object"        },        {          "title": "Success-Response:",          "content": "{\n               \"message\": \"No results found.\",\n               \"data\": {}\n           }",          "type": "object"        }      ]    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "type": "String",            "optional": false,            "field": "message",            "description": "<p>Error message</p>"          },          {            "group": "Error 4xx",            "type": "Object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Error-Response:",          "content": "{\"message\": \"Validation failed\", \"data\": {}}",          "type": "object"        }      ]    },    "filename": "routes/api/search.js",    "groupTitle": "Search",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/search/:model"      }    ]  },  {    "type": "post",    "url": "/sponsor/",    "title": "create a new sponsor",    "name": "createSponsor",    "group": "Sponsor",    "version": "0.0.8",    "parameter": {      "fields": {        "body": [          {            "group": "body",            "type": "MongoID",            "optional": false,            "field": "accountId",            "description": "<p>ObjectID of the respective account.</p>"          },          {            "group": "body",            "type": "Number",            "optional": false,            "field": "tier",            "description": "<p>Tier of the sponsor, from 0 to 5. 0 is lowest tier, and 5 is the custom tier.</p>"          },          {            "group": "body",            "type": "String",            "optional": false,            "field": "company",            "description": "<p>Name of the company.</p>"          },          {            "group": "body",            "type": "String",            "optional": false,            "field": "contractURL",            "description": "<p>URL link to the contract with the company.</p>"          },          {            "group": "body",            "type": "MongoID[]",            "optional": false,            "field": "nominees",            "description": "<p>Array of accounts that the company wish to nominate as hackers.</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "String",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "Object",            "optional": false,            "field": "data",            "description": "<p>Sponsor object</p>"          }        ]      },      "examples": [        {          "title": "Success-Response: ",          "content": "{\n               \"message\": \"Sponsor creation successful\", \n               \"data\": {...}\n           }",          "type": "object"        }      ]    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "type": "String",            "optional": false,            "field": "message",            "description": "<p>Error message</p>"          },          {            "group": "Error 4xx",            "type": "Object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Error-Response: ",          "content": "{\"message\": \"Error while creating sponsor\", \"data\": {}}",          "type": "object"        }      ]    },    "filename": "routes/api/sponsor.js",    "groupTitle": "Sponsor",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/sponsor/"      }    ]  },  {    "type": "get",    "url": "/sponsor/:id",    "title": "get a sponsor's information",    "name": "getSponsor",    "group": "Sponsor",    "version": "0.0.8",    "parameter": {      "fields": {        "param": [          {            "group": "param",            "type": "string",            "optional": false,            "field": "id",            "description": "<p>a sponsor's unique mongoID</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "String",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "Object",            "optional": false,            "field": "data",            "description": "<p>Sponsor object</p>"          }        ]      },      "examples": [        {          "title": "Success-Response: ",          "content": "{\n               \"message\": \"Successfully retrieved sponsor information\", \n               \"data\": {...}\n           }",          "type": "object"        }      ]    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "type": "String",            "optional": false,            "field": "message",            "description": "<p>Error message</p>"          },          {            "group": "Error 4xx",            "type": "Object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Error-Response: ",          "content": "{\"message\": \"Sponsor not found\", \"data\": {}}",          "type": "object"        }      ]    },    "filename": "routes/api/sponsor.js",    "groupTitle": "Sponsor",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/sponsor/:id"      }    ]  },  {    "type": "post",    "url": "/team/",    "title": "create a new team",    "name": "createTeam",    "group": "Team",    "version": "0.0.8",    "parameter": {      "fields": {        "body": [          {            "group": "body",            "type": "String",            "optional": false,            "field": "name",            "description": "<p>Name of the team.</p>"          },          {            "group": "body",            "type": "MongoID[]",            "optional": true,            "field": "members",            "description": "<p>Array of members in team.</p>"          },          {            "group": "body",            "type": "String",            "optional": true,            "field": "devpostURL",            "description": "<p>Devpost link to hack. Once the link is sent, the hack will be considered to be submitted.</p>"          },          {            "group": "body",            "type": "String",            "optional": false,            "field": "projectName",            "description": "<p>Name of the team.</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>Team object</p>"          }        ]      },      "examples": [        {          "title": "Success-Response: ",          "content": "{\n               \"message\": \"Team creation successful\", \n               \"data\": {...}\n           }",          "type": "object"        }      ]    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Error message</p>"          },          {            "group": "Error 4xx",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Error-Response: ",          "content": "{\"message\": \"Error while creating team\", \"data\": {}}",          "type": "object"        }      ]    },    "filename": "routes/api/team.js",    "groupTitle": "Team",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/team/"      }    ]  },  {    "type": "get",    "url": "/team/:id",    "title": "get a team's information",    "name": "getTeam",    "group": "Team",    "version": "0.0.8",    "parameter": {      "fields": {        "param": [          {            "group": "param",            "type": "ObjectId",            "optional": false,            "field": "id",            "description": "<p>a team's unique mongoId</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "String",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "Object",            "optional": false,            "field": "data",            "description": "<p>Sponsor object</p>"          }        ]      },      "examples": [        {          "title": "Success-Response: ",          "content": "{\n               \"message\": \"Successfully retrieved team information\", \n               \"data\": {...}\n           }",          "type": "object"        }      ]    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "type": "String",            "optional": false,            "field": "message",            "description": "<p>Error message</p>"          },          {            "group": "Error 4xx",            "type": "Object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Error-Response: ",          "content": "{\"message\": \"Team not found\", \"data\": {}}",          "type": "object"        }      ]    },    "filename": "routes/api/team.js",    "groupTitle": "Team",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/team/:id"      }    ]  },  {    "type": "post",    "url": "/volunteer/",    "title": "create a new volunteer",    "name": "createVolunteer",    "group": "Volunteer",    "version": "0.0.8",    "parameter": {      "fields": {        "body": [          {            "group": "body",            "type": "MongoID",            "optional": false,            "field": "accountId",            "description": "<p>MongoID of the account of the volunteer</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>Volunteer object</p>"          }        ]      },      "examples": [        {          "title": "Success-Response: ",          "content": "{\n               \"message\": \"Volunteer creation successful\", \n               \"data\": {...}\n           }",          "type": "object"        }      ]    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Error message</p>"          },          {            "group": "Error 4xx",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Error-Response: ",          "content": "{\"message\": \"Error while creating volunteer\", \"data\": {}}",          "type": "object"        }      ]    },    "filename": "routes/api/volunteer.js",    "groupTitle": "Volunteer",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/volunteer/"      }    ]  }]

--- a/docs/api/api_data.json
+++ b/docs/api/api_data.json
@@ -545,7 +545,7 @@
       },
       "examples": [{
         "title": "Error-Response: ",
-        "content": "{\"message\": \"Invalid email or password\", \"data\": {}}",
+        "content": "{\"message\": \"Invalid Authentication\", \"data\": {}}",
         "type": "object"
       }]
     },

--- a/docs/api/api_data.json
+++ b/docs/api/api_data.json
@@ -1,1 +1,1768 @@
-[  {    "type": "post",    "url": "/account/",    "title": "create a new account",    "name": "create",    "group": "Account",    "version": "0.0.8",    "parameter": {      "fields": {        "body": [          {            "group": "body",            "type": "String",            "optional": false,            "field": "firstName",            "description": "<p>First name of the account creator.</p>"          },          {            "group": "body",            "type": "String",            "optional": false,            "field": "lastName",            "description": "<p>Last name of the account creator.</p>"          },          {            "group": "body",            "type": "String",            "optional": false,            "field": "email",            "description": "<p>Email of the account.</p>"          },          {            "group": "body",            "type": "String",            "optional": false,            "field": "dietaryRestrictions",            "description": "<p>Any dietary restrictions for the user. 'None' if there are no restrictions</p>"          },          {            "group": "body",            "type": "String",            "optional": false,            "field": "shirtSize",            "description": "<p>Size of the shirt that the user will receive.</p>"          },          {            "group": "body",            "type": "String",            "optional": false,            "field": "passowrd",            "description": "<p>The password of the account.</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>Account object</p>"          }        ]      },      "examples": [        {          "title": "Success-Response: ",          "content": "{\n               \"message\": \"Account creation successful\", \n               \"data\": {...}\n           }",          "type": "object"        }      ]    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Error message</p>"          },          {            "group": "Error 4xx",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Error-Response: ",          "content": "{\"message\": \"Account already exists\", \"data\": {}}",          "type": "object"        }      ]    },    "filename": "routes/api/account.js",    "groupTitle": "Account",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/account/"      }    ]  },  {    "type": "get",    "url": "/account/:id",    "title": "gets information from an account with mongoid ':id'",    "name": "getAccount",    "group": "Account",    "version": "0.0.8",    "parameter": {      "fields": {        "param": [          {            "group": "param",            "type": "ObjectId",            "optional": false,            "field": "id",            "description": "<p>MongoId of an account</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>Account object</p>"          }        ]      },      "examples": [        {          "title": "Success-Response: ",          "content": "{\n               \"message\": \"Account found by user id\", \n               \"data\": {AccountObject}\n           }",          "type": "object"        }      ]    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Error message</p>"          },          {            "group": "Error 4xx",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Error-Response: ",          "content": "{\"message\": \"Account not found\", \"data\": {}}",          "type": "object"        }      ]    },    "filename": "routes/api/account.js",    "groupTitle": "Account",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/account/:id"      }    ]  },  {    "type": "get",    "url": "/account/self",    "title": "get information about own account",    "name": "self",    "group": "Account",    "version": "0.0.8",    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>Account object</p>"          }        ]      },      "examples": [        {          "title": "Success-Response: ",          "content": "{\n               \"message\": \"Account found by user email\", \n               \"data\": {AccountObject}\n           }",          "type": "object"        }      ]    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Error message</p>"          },          {            "group": "Error 4xx",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Error-Response: ",          "content": "{\"message\": \"Account not found\", \"data\": {}}",          "type": "object"        }      ]    },    "filename": "routes/api/account.js",    "groupTitle": "Account",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/account/self"      }    ]  },  {    "type": "patch",    "url": "/account/:id",    "title": "update an account's information",    "name": "updateOneUser",    "group": "Account",    "version": "0.0.8",    "parameter": {      "fields": {        "body": [          {            "group": "body",            "type": "String",            "optional": true,            "field": "firstName",            "description": "<p>First name of the account creator.</p>"          },          {            "group": "body",            "type": "String",            "optional": true,            "field": "lastName",            "description": "<p>Last name of the account creator.</p>"          },          {            "group": "body",            "type": "String",            "optional": true,            "field": "email",            "description": "<p>Email of the account.</p>"          },          {            "group": "body",            "type": "String",            "optional": true,            "field": "dietaryRestrictions",            "description": "<p>Any dietary restrictions for the user. 'None' if there are no restrictions</p>"          },          {            "group": "body",            "type": "String",            "optional": true,            "field": "shirtSize",            "description": "<p>Size of the shirt that the user will receive.</p>"          },          {            "group": "body",            "type": "String",            "optional": true,            "field": "passowrd",            "description": "<p>The password of the account.</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>Account object</p>"          }        ]      },      "examples": [        {          "title": "Success-Response: ",          "content": "{\n               \"message\": \"Changed account information\", \n               \"data\": {...}\n           }",          "type": "object"        }      ]    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Error message</p>"          },          {            "group": "Error 4xx",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Error-Response: ",          "content": "{\"message\": \"Error while updating account\", \"data\": {}}",          "type": "object"        }      ]    },    "filename": "routes/api/account.js",    "groupTitle": "Account",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/account/:id"      }    ]  },  {    "type": "post",    "url": "/auth/confirm/:token",    "title": "confirm account using the JWT in :token",    "name": "confirmAccount",    "group": "Authentication",    "version": "0.0.8",    "parameter": {      "fields": {        "Parameter": [          {            "group": "Parameter",            "type": "String",            "optional": false,            "field": "JWT",            "description": "<p>for confirming the account</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Success-Response:",          "content": "{\"message\": \"Successfully confirmed account\", \"data\": {}}",          "type": "json"        }      ]    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Error message</p>"          },          {            "group": "Error 4xx",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Error-Response: ",          "content": "{\"message\": \"Invalid token for confirming account, \"data\": {}}",          "type": "object"        }      ]    },    "filename": "routes/api/auth.js",    "groupTitle": "Authentication",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/auth/confirm/:token"      }    ]  },  {    "type": "post",    "url": "/auth/password/forgot",    "title": "forgot password route",    "name": "forgotPassword",    "group": "Authentication",    "version": "0.0.8",    "parameter": {      "fields": {        "Parameter": [          {            "group": "Parameter",            "type": "String",            "optional": false,            "field": "email",            "description": "<p>the email address of the account</p>"          }        ]      },      "examples": [        {          "title": "Request-Example:",          "content": "{ \"email\": \"myemail@mchacks.ca\" }",          "type": "json"        }      ]    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Success-Response: ",          "content": "{\"message\": \"Sent reset email\", \"data\": {}}",          "type": "json"        }      ]    },    "permission": [      {        "name": ": public"      }    ],    "filename": "routes/api/auth.js",    "groupTitle": "Authentication",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/auth/password/forgot"      }    ]  },  {    "type": "post",    "url": "/auth/login",    "title": "login to the service",    "name": "login",    "group": "Authentication",    "version": "0.0.8",    "parameter": {      "fields": {        "Parameter": [          {            "group": "Parameter",            "type": "string",            "optional": false,            "field": "email",            "description": "<p>Account email</p>"          },          {            "group": "Parameter",            "type": "string",            "optional": false,            "field": "password",            "description": "<p>Account password</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Success-Response: ",          "content": "{\"message\": \"Successfully logged in\", \"data\": {}}",          "type": "object"        }      ]    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Error message</p>"          },          {            "group": "Error 4xx",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Error-Response: ",          "content": "{\"message\": \"Invalid email or password\", \"data\": {}}",          "type": "object"        }      ]    },    "permission": [      {        "name": ": public"      }    ],    "filename": "routes/api/auth.js",    "groupTitle": "Authentication",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/auth/login"      }    ]  },  {    "type": "get",    "url": "/auth/logout",    "title": "logout of service",    "name": "logout",    "group": "Authentication",    "version": "0.0.8",    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Success-Response: ",          "content": "{\"message\": \"Successfully logged out\", \"data\": {}}",          "type": "object"        }      ]    },    "permission": [      {        "name": ": public"      }    ],    "filename": "routes/api/auth.js",    "groupTitle": "Authentication",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/auth/logout"      }    ]  },  {    "type": "get",    "url": "/auth/confirm/resend",    "title": "resend confirmation token",    "name": "resendConfirmAccount",    "group": "Authentication",    "version": "0.0.8",    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Success-Response:",          "content": "{\"message\": \"Successfully resent confirmation email\", \"data\": {}}",          "type": "json"        }      ]    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Error message</p>"          },          {            "group": "Error 4xx",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Error-Response:",          "content": " HTTP/1.1 422\n{\"message\": \"Account already confirmed, \"data\": {}}",          "type": "json"        },        {          "title": "Error-Response:",          "content": " HTTP/1.1 428\n{\"message\": \"Account already confirmed, \"data\": {}}",          "type": "json"        }      ]    },    "filename": "routes/api/auth.js",    "groupTitle": "Authentication",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/auth/confirm/resend"      }    ]  },  {    "type": "post",    "url": "/auth/password/reset",    "title": "reset password",    "name": "resetPassword",    "group": "Authentication",    "version": "0.0.8",    "parameter": {      "fields": {        "Parameter": [          {            "group": "Parameter",            "type": "String",            "optional": false,            "field": "password",            "description": "<p>the password of the account</p>"          }        ]      },      "examples": [        {          "title": "Request-Example:",          "content": "{ \"password\": \"hunter2\" }",          "type": "json"        }      ]    },    "header": {      "fields": {        "Header": [          {            "group": "Header",            "type": "String",            "optional": false,            "field": "Authentication",            "description": "<p>the token that was provided in the reset password email</p>"          }        ]      },      "examples": [        {          "title": "Header-Example:",          "content": "{\n  \"X-Reset-Token\": \"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c\"\n}",          "type": "json"        }      ]    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Success-Response: ",          "content": "{\"message\": \"Successfully reset password\", \"data\": {}}",          "type": "json"        }      ]    },    "permission": [      {        "name": ": must have authentication token"      }    ],    "filename": "routes/api/auth.js",    "groupTitle": "Authentication",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/auth/password/reset"      }    ]  },  {    "type": "get",    "url": "/auth/rolebindings/:id",    "title": "retrieve rolebindings for a user given by their user id :id",    "name": "getRoleBindings",    "group": "Auth",    "version": "0.0.8",    "parameter": {      "fields": {        "param": [          {            "group": "param",            "type": "ObjectId",            "optional": false,            "field": "id",            "description": "<p>MongoId of an account</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>Rolebindings object</p>"          }        ]      },      "examples": [        {          "title": "Success-Response: ",          "content": "{\n               \"message\": \"Successfully retrieved role bindings\",\n               \"data\": {\n                   accountId:\"5beca4ab2e069a34f91697b2\"\n                   id:\"5beca4ae2e069a34f91698b1\"\n                   roles: [\n                       {\n                           _id:\"5beca4ab2e069a34f91697d9\",\n                           name:\"hacker\",\n                           routes: [\n                               0:Object {_id: \"5beca4ae2e069a34f9169852\", requestType: \"POST\", uri: \"/api/auth/login\"},\n                               1:Object {_id: \"5beca4ae2e069a34f9169851\", requestType: \"POST\", uri: \"/api/auth/logout\"},\n                               2:Object {_id: \"5beca4ae2e069a34f9169850\", requestType: \"GET\", uri: \"/api/auth/rolebindings/:self\"},\n                               3:Object {_id: \"5beca4ae2e069a34f916984f\", requestType: \"GET\", uri: \"/api/account/self\"},\n                               4:Object {_id: \"5beca4ae2e069a34f916984e\", requestType: \"GET\", uri: \"/api/account/:self\"},\n                               5:Object {_id: \"5beca4ae2e069a34f916984d\", requestType: \"PATCH\", uri: \"/api/account/:self\"},\n                               6:Object {_id: \"5beca4ae2e069a34f916984c\", requestType: \"POST\", uri: \"/api/hacker/\"},\n                               7:Object {_id: \"5beca4ae2e069a34f916984b\", requestType: \"GET\", uri: \"/api/hacker/:self\"},\n                               8:Object {_id: \"5beca4ae2e069a34f916984a\", requestType: \"GET\", uri: \"/api/hacker/:self/resume\"},\n                               9:Object {_id: \"5beca4ae2e069a34f9169849\", requestType: \"PATCH\", uri: \"/api/hacker/:self\"}\n                           ]\n                       }\n                   ]\n               }\n           }",          "type": "object"        }      ]    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Error message</p>"          },          {            "group": "Error 4xx",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Error-Response: ",          "content": "{\"message\": \"Role Bindings not found\", \"data\": {}}",          "type": "object"        }      ]    },    "filename": "routes/api/auth.js",    "groupTitle": "Auth",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/auth/rolebindings/:id"      }    ]  },  {    "type": "post",    "url": "/hacker/",    "title": "create a new hacker",    "name": "createHacker",    "group": "Hacker",    "version": "0.0.8",    "parameter": {      "fields": {        "body": [          {            "group": "body",            "type": "MongoID",            "optional": false,            "field": "accountId",            "description": "<p>ObjectID of the respective account</p>"          },          {            "group": "body",            "type": "String",            "optional": false,            "field": "school",            "description": "<p>Name of the school the hacker goes to</p>"          },          {            "group": "body",            "type": "String",            "optional": false,            "field": "gender",            "description": "<p>Gender of the hacker</p>"          },          {            "group": "body",            "type": "Boolean",            "optional": false,            "field": "needsBus",            "description": "<p>Whether the hacker requires a bus for transportation</p>"          },          {            "group": "body",            "type": "Json",            "optional": false,            "field": "application",            "description": "<p>The hacker's application. Resume and jobInterest fields are required.</p>"          }        ]      },      "examples": [        {          "title": "application: ",          "content": "{\n    \"portfolioURL\": {\n        \"resume\": \"...\"\n        \"github\": \"...\",\n        \"dropler\": \"...\",\n        \"personal\": \"...\",\n        \"linkedIn\": \"...\",\n        \"other\": \"...\"\n    },\n    \"jobInterest\": \"...\",\n    \"skills\": [\"CSS\", \"HTML\"],    \n    \"comments\": \"...\",\n    \"essay\": \"...\",\n    \"team\": [id1, id2],\n}",          "type": "Json"        }      ]    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>Hacker object</p>"          }        ]      },      "examples": [        {          "title": "Success-Response: ",          "content": "{\n    \"message\": \"Hacker creation successful\", \n    \"data\": {...}\n}",          "type": "object"        }      ]    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Error message</p>"          },          {            "group": "Error 4xx",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Error-Response: ",          "content": "{\"message\": \"Error while creating hacker\", \"data\": {}}",          "type": "object"        }      ]    },    "filename": "routes/api/hacker.js",    "groupTitle": "Hacker",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/hacker/"      }    ]  },  {    "type": "get",    "url": "/hacker/:id",    "title": "get a hacker's information",    "name": "getHacker",    "group": "Hacker",    "version": "0.0.8",    "parameter": {      "fields": {        "param": [          {            "group": "param",            "type": "String",            "optional": false,            "field": "id",            "description": "<p>a hacker's unique mongoID</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "String",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "Object",            "optional": false,            "field": "data",            "description": "<p>Sponsor object</p>"          }        ]      },      "examples": [        {          "title": "Success-Response: ",          "content": "{\n               \"message\": \"Successfully retrieved hacker information\", \n               \"data\": {...}\n           }",          "type": "object"        }      ]    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "type": "String",            "optional": false,            "field": "message",            "description": "<p>Error message</p>"          },          {            "group": "Error 4xx",            "type": "Object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Error-Response: ",          "content": "{\"message\": \"Hacker not found\", \"data\": {}}",          "type": "object"        }      ]    },    "filename": "routes/api/hacker.js",    "groupTitle": "Hacker",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/hacker/:id"      }    ]  },  {    "type": "get",    "url": "/hacker/resume:id",    "title": "get the resume for a hacker.",    "name": "getHackerResume",    "group": "Hacker",    "version": "0.0.8",    "parameter": {      "fields": {        "param": [          {            "group": "param",            "type": "ObjectId",            "optional": false,            "field": "id",            "description": "<p>Hacker id</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "String",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          }        ]      },      "examples": [        {          "title": "Success-Response:",          "content": "HTTP/1.1 200 OK \n{ \n    message: \"Downloaded resume\", \n    data: { \n        id: \"507f191e810c19729de860ea\", \n        resume: [Buffer] \n    } \n}",          "type": "json"        }      ]    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "type": "String",            "optional": false,            "field": "message",            "description": "<p>&quot;Resume does not exist&quot;</p>"          }        ]      },      "examples": [        {          "title": "Error-Response:",          "content": "HTTP/1.1 404 \n{ \n    message: \"Resume not found\", \n    data: {} \n}",          "type": "json"        }      ]    },    "permission": [      {        "name": "Must be logged in, and the account id must be linked to the hacker."      }    ],    "filename": "routes/api/hacker.js",    "groupTitle": "Hacker"  },  {    "type": "patch",    "url": "/hacker/:id",    "title": "update a hacker's information.",    "description": "<p>This route only contains the ability to update a subset of a hacker's information. If you want to update a status, you must have Admin priviledges and use PATCH /hacker/status/:id.</p>",    "name": "patchHacker",    "group": "Hacker",    "version": "0.0.8",    "parameter": {      "fields": {        "body": [          {            "group": "body",            "type": "String",            "optional": true,            "field": "school",            "description": "<p>Name of the school the hacker goes to</p>"          },          {            "group": "body",            "type": "String",            "optional": true,            "field": "gender",            "description": "<p>Gender of the hacker</p>"          },          {            "group": "body",            "type": "Boolean",            "optional": true,            "field": "needsBus",            "description": "<p>Whether the hacker requires a bus for transportation</p>"          },          {            "group": "body",            "type": "Json",            "optional": true,            "field": "application",            "description": "<p>The hacker's application</p>"          }        ]      },      "examples": [        {          "title": "application: ",          "content": "{\n    \"portfolioURL\": {\n        \"resume\": \"...\"\n        \"github\": \"...\",\n        \"dropler\": \"...\",\n        \"personal\": \"...\",\n        \"linkedIn\": \"...\",\n        \"other\": \"...\"\n    },\n    \"jobInterest\": \"...\",\n    \"skills\": [\"CSS\", \"HTML\"],    \n    \"comments\": \"...\",\n    \"essay\": \"...\",\n    \"team\": [id1, id2],\n}",          "type": "Json"        }      ]    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>Hacker object</p>"          }        ]      },      "examples": [        {          "title": "Success-Response: ",          "content": "{\n    \"message\": \"Changed hacker information\", \n    \"data\": {...}\n}",          "type": "object"        }      ]    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Error message</p>"          },          {            "group": "Error 4xx",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Error-Response: ",          "content": "{\"message\": \"Error while updating hacker\", \"data\": {}}",          "type": "object"        }      ]    },    "filename": "routes/api/hacker.js",    "groupTitle": "Hacker",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/hacker/:id"      }    ]  },  {    "type": "patch",    "url": "/hacker/status/:id",    "title": "update a hacker's status",    "name": "patchHackerStatus",    "group": "Hacker",    "version": "0.0.9",    "parameter": {      "fields": {        "body": [          {            "group": "body",            "type": "String",            "optional": true,            "field": "status",            "description": "<p>Status of the hacker's application</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>Hacker object</p>"          }        ]      },      "examples": [        {          "title": "Success-Response: ",          "content": "{\n    \"message\": \"Changed hacker information\", \n    \"data\": {\n        \"status\": \"accepted\"\n    }\n}",          "type": "object"        }      ]    },    "permission": [      {        "name": "Administrator"      }    ],    "filename": "routes/api/hacker.js",    "groupTitle": "Hacker",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/hacker/status/:id"      }    ]  },  {    "type": "post",    "url": "/hacker/resume/:id",    "title": "upload or update resume for a hacker.",    "name": "postHackerResume",    "group": "Hacker",    "version": "0.0.8",    "description": "<p><b>NOTE: This must be sent via multipart/form-data POST request</b></p>",    "parameter": {      "fields": {        "param": [          {            "group": "param",            "type": "ObjectId",            "optional": false,            "field": "id",            "description": "<p>Hacker id</p>"          }        ],        "body": [          {            "group": "body",            "type": "File",            "optional": false,            "field": "resume",            "description": "<p>The uploaded file.</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "String",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "Object",            "optional": false,            "field": "data",            "description": "<p>Location in the bucket that the file was stored.</p>"          }        ]      },      "examples": [        {          "title": "Success-Response: ",          "content": "HTTP/1.1 200 OK\n{\n    message: \"Uploaded resume\", \n    data: {\n        filename: \"resumes/1535032624768-507f191e810c19729de860ea\"\n    }\n}",          "type": "json"        }      ]    },    "permission": [      {        "name": "Must be logged in, and the account id must be linked to the hacker."      }    ],    "filename": "routes/api/hacker.js",    "groupTitle": "Hacker",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/hacker/resume/:id"      }    ]  },  {    "type": "get",    "url": "/",    "title": "version",    "version": "0.0.8",    "name": "index",    "group": "Index",    "permission": [      {        "name": "public"      }    ],    "filename": "routes/index.js",    "groupTitle": "Index",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/"      }    ]  },  {    "type": "get",    "url": "/search/:model",    "title": "provide a specific query for any defined model",    "name": "search",    "group": "Search",    "version": "0.0.8",    "parameter": {      "fields": {        "param": [          {            "group": "param",            "type": "String",            "optional": false,            "field": "model",            "description": "<p>the model to be searched</p>"          }        ],        "query": [          {            "group": "query",            "type": "Array",            "optional": false,            "field": "q",            "description": "<p>the query to be executed. For more information on how to format this, please see https://hackerapi.mchacks.ca/architecture/</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "String",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "Object",            "optional": false,            "field": "data",            "description": "<p>Results</p>"          }        ]      },      "examples": [        {          "title": "Success-Response:",          "content": "{\n               \"message\": \"Successfully executed query, returning all results\",\n               \"data\": [\n                   {...}\n               ]\n           }",          "type": "object"        },        {          "title": "Success-Response:",          "content": "{\n               \"message\": \"No results found.\",\n               \"data\": {}\n           }",          "type": "object"        }      ]    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "type": "String",            "optional": false,            "field": "message",            "description": "<p>Error message</p>"          },          {            "group": "Error 4xx",            "type": "Object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Error-Response:",          "content": "{\"message\": \"Validation failed\", \"data\": {}}",          "type": "object"        }      ]    },    "filename": "routes/api/search.js",    "groupTitle": "Search",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/search/:model"      }    ]  },  {    "type": "post",    "url": "/sponsor/",    "title": "create a new sponsor",    "name": "createSponsor",    "group": "Sponsor",    "version": "0.0.8",    "parameter": {      "fields": {        "body": [          {            "group": "body",            "type": "MongoID",            "optional": false,            "field": "accountId",            "description": "<p>ObjectID of the respective account.</p>"          },          {            "group": "body",            "type": "Number",            "optional": false,            "field": "tier",            "description": "<p>Tier of the sponsor, from 0 to 5. 0 is lowest tier, and 5 is the custom tier.</p>"          },          {            "group": "body",            "type": "String",            "optional": false,            "field": "company",            "description": "<p>Name of the company.</p>"          },          {            "group": "body",            "type": "String",            "optional": false,            "field": "contractURL",            "description": "<p>URL link to the contract with the company.</p>"          },          {            "group": "body",            "type": "MongoID[]",            "optional": false,            "field": "nominees",            "description": "<p>Array of accounts that the company wish to nominate as hackers.</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "String",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "Object",            "optional": false,            "field": "data",            "description": "<p>Sponsor object</p>"          }        ]      },      "examples": [        {          "title": "Success-Response: ",          "content": "{\n               \"message\": \"Sponsor creation successful\", \n               \"data\": {...}\n           }",          "type": "object"        }      ]    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "type": "String",            "optional": false,            "field": "message",            "description": "<p>Error message</p>"          },          {            "group": "Error 4xx",            "type": "Object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Error-Response: ",          "content": "{\"message\": \"Error while creating sponsor\", \"data\": {}}",          "type": "object"        }      ]    },    "filename": "routes/api/sponsor.js",    "groupTitle": "Sponsor",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/sponsor/"      }    ]  },  {    "type": "get",    "url": "/sponsor/:id",    "title": "get a sponsor's information",    "name": "getSponsor",    "group": "Sponsor",    "version": "0.0.8",    "parameter": {      "fields": {        "param": [          {            "group": "param",            "type": "string",            "optional": false,            "field": "id",            "description": "<p>a sponsor's unique mongoID</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "String",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "Object",            "optional": false,            "field": "data",            "description": "<p>Sponsor object</p>"          }        ]      },      "examples": [        {          "title": "Success-Response: ",          "content": "{\n               \"message\": \"Successfully retrieved sponsor information\", \n               \"data\": {...}\n           }",          "type": "object"        }      ]    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "type": "String",            "optional": false,            "field": "message",            "description": "<p>Error message</p>"          },          {            "group": "Error 4xx",            "type": "Object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Error-Response: ",          "content": "{\"message\": \"Sponsor not found\", \"data\": {}}",          "type": "object"        }      ]    },    "filename": "routes/api/sponsor.js",    "groupTitle": "Sponsor",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/sponsor/:id"      }    ]  },  {    "type": "post",    "url": "/team/",    "title": "create a new team",    "name": "createTeam",    "group": "Team",    "version": "0.0.8",    "parameter": {      "fields": {        "body": [          {            "group": "body",            "type": "String",            "optional": false,            "field": "name",            "description": "<p>Name of the team.</p>"          },          {            "group": "body",            "type": "MongoID[]",            "optional": true,            "field": "members",            "description": "<p>Array of members in team.</p>"          },          {            "group": "body",            "type": "String",            "optional": true,            "field": "devpostURL",            "description": "<p>Devpost link to hack. Once the link is sent, the hack will be considered to be submitted.</p>"          },          {            "group": "body",            "type": "String",            "optional": false,            "field": "projectName",            "description": "<p>Name of the team.</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>Team object</p>"          }        ]      },      "examples": [        {          "title": "Success-Response: ",          "content": "{\n               \"message\": \"Team creation successful\", \n               \"data\": {...}\n           }",          "type": "object"        }      ]    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Error message</p>"          },          {            "group": "Error 4xx",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Error-Response: ",          "content": "{\"message\": \"Error while creating team\", \"data\": {}}",          "type": "object"        }      ]    },    "filename": "routes/api/team.js",    "groupTitle": "Team",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/team/"      }    ]  },  {    "type": "get",    "url": "/team/:id",    "title": "get a team's information",    "name": "getTeam",    "group": "Team",    "version": "0.0.8",    "parameter": {      "fields": {        "param": [          {            "group": "param",            "type": "ObjectId",            "optional": false,            "field": "id",            "description": "<p>a team's unique mongoId</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "String",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "Object",            "optional": false,            "field": "data",            "description": "<p>Sponsor object</p>"          }        ]      },      "examples": [        {          "title": "Success-Response: ",          "content": "{\n               \"message\": \"Successfully retrieved team information\", \n               \"data\": {...}\n           }",          "type": "object"        }      ]    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "type": "String",            "optional": false,            "field": "message",            "description": "<p>Error message</p>"          },          {            "group": "Error 4xx",            "type": "Object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Error-Response: ",          "content": "{\"message\": \"Team not found\", \"data\": {}}",          "type": "object"        }      ]    },    "filename": "routes/api/team.js",    "groupTitle": "Team",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/team/:id"      }    ]  },  {    "type": "post",    "url": "/volunteer/",    "title": "create a new volunteer",    "name": "createVolunteer",    "group": "Volunteer",    "version": "0.0.8",    "parameter": {      "fields": {        "body": [          {            "group": "body",            "type": "MongoID",            "optional": false,            "field": "accountId",            "description": "<p>MongoID of the account of the volunteer</p>"          }        ]      }    },    "success": {      "fields": {        "Success 200": [          {            "group": "Success 200",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Success message</p>"          },          {            "group": "Success 200",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>Volunteer object</p>"          }        ]      },      "examples": [        {          "title": "Success-Response: ",          "content": "{\n               \"message\": \"Volunteer creation successful\", \n               \"data\": {...}\n           }",          "type": "object"        }      ]    },    "error": {      "fields": {        "Error 4xx": [          {            "group": "Error 4xx",            "type": "string",            "optional": false,            "field": "message",            "description": "<p>Error message</p>"          },          {            "group": "Error 4xx",            "type": "object",            "optional": false,            "field": "data",            "description": "<p>empty</p>"          }        ]      },      "examples": [        {          "title": "Error-Response: ",          "content": "{\"message\": \"Error while creating volunteer\", \"data\": {}}",          "type": "object"        }      ]    },    "filename": "routes/api/volunteer.js",    "groupTitle": "Volunteer",    "sampleRequest": [      {        "url": "https://mchacks.ca/api/volunteer/"      }    ]  }]
+[{
+    "type": "post",
+    "url": "/account/",
+    "title": "create a new account",
+    "name": "create",
+    "group": "Account",
+    "version": "0.0.8",
+    "parameter": {
+      "fields": {
+        "body": [{
+            "group": "body",
+            "type": "String",
+            "optional": false,
+            "field": "firstName",
+            "description": "<p>First name of the account creator.</p>"
+          },
+          {
+            "group": "body",
+            "type": "String",
+            "optional": false,
+            "field": "lastName",
+            "description": "<p>Last name of the account creator.</p>"
+          },
+          {
+            "group": "body",
+            "type": "String",
+            "optional": false,
+            "field": "email",
+            "description": "<p>Email of the account.</p>"
+          },
+          {
+            "group": "body",
+            "type": "String",
+            "optional": false,
+            "field": "dietaryRestrictions",
+            "description": "<p>Any dietary restrictions for the user. 'None' if there are no restrictions</p>"
+          },
+          {
+            "group": "body",
+            "type": "String",
+            "optional": false,
+            "field": "shirtSize",
+            "description": "<p>Size of the shirt that the user will receive.</p>"
+          },
+          {
+            "group": "body",
+            "type": "String",
+            "optional": false,
+            "field": "passowrd",
+            "description": "<p>The password of the account.</p>"
+          }
+        ]
+      }
+    },
+    "success": {
+      "fields": {
+        "Success 200": [{
+            "group": "Success 200",
+            "type": "string",
+            "optional": false,
+            "field": "message",
+            "description": "<p>Success message</p>"
+          },
+          {
+            "group": "Success 200",
+            "type": "object",
+            "optional": false,
+            "field": "data",
+            "description": "<p>Account object</p>"
+          }
+        ]
+      },
+      "examples": [{
+        "title": "Success-Response: ",
+        "content": "{\n               \"message\": \"Account creation successful\", \n               \"data\": {...}\n           }",
+        "type": "object"
+      }]
+    },
+    "error": {
+      "fields": {
+        "Error 4xx": [{
+            "group": "Error 4xx",
+            "type": "string",
+            "optional": false,
+            "field": "message",
+            "description": "<p>Error message</p>"
+          },
+          {
+            "group": "Error 4xx",
+            "type": "object",
+            "optional": false,
+            "field": "data",
+            "description": "<p>empty</p>"
+          }
+        ]
+      },
+      "examples": [{
+        "title": "Error-Response: ",
+        "content": "{\"message\": \"Account already exists\", \"data\": {}}",
+        "type": "object"
+      }]
+    },
+    "filename": "routes/api/account.js",
+    "groupTitle": "Account",
+    "sampleRequest": [{
+      "url": "https://mchacks.ca/api/account/"
+    }]
+  },
+  {
+    "type": "get",
+    "url": "/account/:id",
+    "title": "gets information from an account with mongoid ':id'",
+    "name": "getAccount",
+    "group": "Account",
+    "version": "0.0.8",
+    "parameter": {
+      "fields": {
+        "param": [{
+          "group": "param",
+          "type": "ObjectId",
+          "optional": false,
+          "field": "id",
+          "description": "<p>MongoId of an account</p>"
+        }]
+      }
+    },
+    "success": {
+      "fields": {
+        "Success 200": [{
+            "group": "Success 200",
+            "type": "string",
+            "optional": false,
+            "field": "message",
+            "description": "<p>Success message</p>"
+          },
+          {
+            "group": "Success 200",
+            "type": "object",
+            "optional": false,
+            "field": "data",
+            "description": "<p>Account object</p>"
+          }
+        ]
+      },
+      "examples": [{
+        "title": "Success-Response: ",
+        "content": "{\n               \"message\": \"Account found by user id\", \n               \"data\": {AccountObject}\n           }",
+        "type": "object"
+      }]
+    },
+    "error": {
+      "fields": {
+        "Error 4xx": [{
+            "group": "Error 4xx",
+            "type": "string",
+            "optional": false,
+            "field": "message",
+            "description": "<p>Error message</p>"
+          },
+          {
+            "group": "Error 4xx",
+            "type": "object",
+            "optional": false,
+            "field": "data",
+            "description": "<p>empty</p>"
+          }
+        ]
+      },
+      "examples": [{
+        "title": "Error-Response: ",
+        "content": "{\"message\": \"Account not found\", \"data\": {}}",
+        "type": "object"
+      }]
+    },
+    "filename": "routes/api/account.js",
+    "groupTitle": "Account",
+    "sampleRequest": [{
+      "url": "https://mchacks.ca/api/account/:id"
+    }]
+  },
+  {
+    "type": "get",
+    "url": "/account/self",
+    "title": "get information about own account",
+    "name": "self",
+    "group": "Account",
+    "version": "0.0.8",
+    "success": {
+      "fields": {
+        "Success 200": [{
+            "group": "Success 200",
+            "type": "string",
+            "optional": false,
+            "field": "message",
+            "description": "<p>Success message</p>"
+          },
+          {
+            "group": "Success 200",
+            "type": "object",
+            "optional": false,
+            "field": "data",
+            "description": "<p>Account object</p>"
+          }
+        ]
+      },
+      "examples": [{
+        "title": "Success-Response: ",
+        "content": "{\n               \"message\": \"Account found by user email\", \n               \"data\": {AccountObject}\n           }",
+        "type": "object"
+      }]
+    },
+    "error": {
+      "fields": {
+        "Error 4xx": [{
+            "group": "Error 4xx",
+            "type": "string",
+            "optional": false,
+            "field": "message",
+            "description": "<p>Error message</p>"
+          },
+          {
+            "group": "Error 4xx",
+            "type": "object",
+            "optional": false,
+            "field": "data",
+            "description": "<p>empty</p>"
+          }
+        ]
+      },
+      "examples": [{
+        "title": "Error-Response: ",
+        "content": "{\"message\": \"Account not found\", \"data\": {}}",
+        "type": "object"
+      }]
+    },
+    "filename": "routes/api/account.js",
+    "groupTitle": "Account",
+    "sampleRequest": [{
+      "url": "https://mchacks.ca/api/account/self"
+    }]
+  },
+  {
+    "type": "patch",
+    "url": "/account/:id",
+    "title": "update an account's information",
+    "name": "updateOneUser",
+    "group": "Account",
+    "version": "0.0.8",
+    "parameter": {
+      "fields": {
+        "body": [{
+            "group": "body",
+            "type": "String",
+            "optional": true,
+            "field": "firstName",
+            "description": "<p>First name of the account creator.</p>"
+          },
+          {
+            "group": "body",
+            "type": "String",
+            "optional": true,
+            "field": "lastName",
+            "description": "<p>Last name of the account creator.</p>"
+          },
+          {
+            "group": "body",
+            "type": "String",
+            "optional": true,
+            "field": "email",
+            "description": "<p>Email of the account.</p>"
+          },
+          {
+            "group": "body",
+            "type": "String",
+            "optional": true,
+            "field": "dietaryRestrictions",
+            "description": "<p>Any dietary restrictions for the user. 'None' if there are no restrictions</p>"
+          },
+          {
+            "group": "body",
+            "type": "String",
+            "optional": true,
+            "field": "shirtSize",
+            "description": "<p>Size of the shirt that the user will receive.</p>"
+          },
+          {
+            "group": "body",
+            "type": "String",
+            "optional": true,
+            "field": "passowrd",
+            "description": "<p>The password of the account.</p>"
+          }
+        ]
+      }
+    },
+    "success": {
+      "fields": {
+        "Success 200": [{
+            "group": "Success 200",
+            "type": "string",
+            "optional": false,
+            "field": "message",
+            "description": "<p>Success message</p>"
+          },
+          {
+            "group": "Success 200",
+            "type": "object",
+            "optional": false,
+            "field": "data",
+            "description": "<p>Account object</p>"
+          }
+        ]
+      },
+      "examples": [{
+        "title": "Success-Response: ",
+        "content": "{\n               \"message\": \"Changed account information\", \n               \"data\": {...}\n           }",
+        "type": "object"
+      }]
+    },
+    "error": {
+      "fields": {
+        "Error 4xx": [{
+            "group": "Error 4xx",
+            "type": "string",
+            "optional": false,
+            "field": "message",
+            "description": "<p>Error message</p>"
+          },
+          {
+            "group": "Error 4xx",
+            "type": "object",
+            "optional": false,
+            "field": "data",
+            "description": "<p>empty</p>"
+          }
+        ]
+      },
+      "examples": [{
+        "title": "Error-Response: ",
+        "content": "{\"message\": \"Error while updating account\", \"data\": {}}",
+        "type": "object"
+      }]
+    },
+    "filename": "routes/api/account.js",
+    "groupTitle": "Account",
+    "sampleRequest": [{
+      "url": "https://mchacks.ca/api/account/:id"
+    }]
+  },
+  {
+    "type": "post",
+    "url": "/auth/confirm/:token",
+    "title": "confirm account using the JWT in :token",
+    "name": "confirmAccount",
+    "group": "Authentication",
+    "version": "0.0.8",
+    "parameter": {
+      "fields": {
+        "Parameter": [{
+          "group": "Parameter",
+          "type": "String",
+          "optional": false,
+          "field": "JWT",
+          "description": "<p>for confirming the account</p>"
+        }]
+      }
+    },
+    "success": {
+      "fields": {
+        "Success 200": [{
+            "group": "Success 200",
+            "type": "string",
+            "optional": false,
+            "field": "message",
+            "description": "<p>Success message</p>"
+          },
+          {
+            "group": "Success 200",
+            "type": "object",
+            "optional": false,
+            "field": "data",
+            "description": "<p>empty</p>"
+          }
+        ]
+      },
+      "examples": [{
+        "title": "Success-Response:",
+        "content": "{\"message\": \"Successfully confirmed account\", \"data\": {}}",
+        "type": "json"
+      }]
+    },
+    "error": {
+      "fields": {
+        "Error 4xx": [{
+            "group": "Error 4xx",
+            "type": "string",
+            "optional": false,
+            "field": "message",
+            "description": "<p>Error message</p>"
+          },
+          {
+            "group": "Error 4xx",
+            "type": "object",
+            "optional": false,
+            "field": "data",
+            "description": "<p>empty</p>"
+          }
+        ]
+      },
+      "examples": [{
+        "title": "Error-Response: ",
+        "content": "{\"message\": \"Invalid token for confirming account, \"data\": {}}",
+        "type": "object"
+      }]
+    },
+    "filename": "routes/api/auth.js",
+    "groupTitle": "Authentication",
+    "sampleRequest": [{
+      "url": "https://mchacks.ca/api/auth/confirm/:token"
+    }]
+  },
+  {
+    "type": "post",
+    "url": "/auth/password/forgot",
+    "title": "forgot password route",
+    "name": "forgotPassword",
+    "group": "Authentication",
+    "version": "0.0.8",
+    "parameter": {
+      "fields": {
+        "Parameter": [{
+          "group": "Parameter",
+          "type": "String",
+          "optional": false,
+          "field": "email",
+          "description": "<p>the email address of the account</p>"
+        }]
+      },
+      "examples": [{
+        "title": "Request-Example:",
+        "content": "{ \"email\": \"myemail@mchacks.ca\" }",
+        "type": "json"
+      }]
+    },
+    "success": {
+      "fields": {
+        "Success 200": [{
+            "group": "Success 200",
+            "type": "string",
+            "optional": false,
+            "field": "message",
+            "description": "<p>Success message</p>"
+          },
+          {
+            "group": "Success 200",
+            "type": "object",
+            "optional": false,
+            "field": "data",
+            "description": "<p>empty</p>"
+          }
+        ]
+      },
+      "examples": [{
+        "title": "Success-Response: ",
+        "content": "{\"message\": \"Sent reset email\", \"data\": {}}",
+        "type": "json"
+      }]
+    },
+    "permission": [{
+      "name": ": public"
+    }],
+    "filename": "routes/api/auth.js",
+    "groupTitle": "Authentication",
+    "sampleRequest": [{
+      "url": "https://mchacks.ca/api/auth/password/forgot"
+    }]
+  },
+  {
+    "type": "post",
+    "url": "/auth/login",
+    "title": "login to the service",
+    "name": "login",
+    "group": "Authentication",
+    "version": "0.0.8",
+    "parameter": {
+      "fields": {
+        "Parameter": [{
+            "group": "Parameter",
+            "type": "string",
+            "optional": false,
+            "field": "email",
+            "description": "<p>Account email</p>"
+          },
+          {
+            "group": "Parameter",
+            "type": "string",
+            "optional": false,
+            "field": "password",
+            "description": "<p>Account password</p>"
+          }
+        ]
+      }
+    },
+    "success": {
+      "fields": {
+        "Success 200": [{
+            "group": "Success 200",
+            "type": "string",
+            "optional": false,
+            "field": "message",
+            "description": "<p>Success message</p>"
+          },
+          {
+            "group": "Success 200",
+            "type": "object",
+            "optional": false,
+            "field": "data",
+            "description": "<p>empty</p>"
+          }
+        ]
+      },
+      "examples": [{
+        "title": "Success-Response: ",
+        "content": "{\"message\": \"Successfully logged in\", \"data\": {}}",
+        "type": "object"
+      }]
+    },
+    "error": {
+      "fields": {
+        "Error 4xx": [{
+            "group": "Error 4xx",
+            "type": "string",
+            "optional": false,
+            "field": "message",
+            "description": "<p>Error message</p>"
+          },
+          {
+            "group": "Error 4xx",
+            "type": "object",
+            "optional": false,
+            "field": "data",
+            "description": "<p>empty</p>"
+          }
+        ]
+      },
+      "examples": [{
+        "title": "Error-Response: ",
+        "content": "{\"message\": \"Invalid email or password\", \"data\": {}}",
+        "type": "object"
+      }]
+    },
+    "permission": [{
+      "name": ": public"
+    }],
+    "filename": "routes/api/auth.js",
+    "groupTitle": "Authentication",
+    "sampleRequest": [{
+      "url": "https://mchacks.ca/api/auth/login"
+    }]
+  },
+  {
+    "type": "get",
+    "url": "/auth/logout",
+    "title": "logout of service",
+    "name": "logout",
+    "group": "Authentication",
+    "version": "0.0.8",
+    "success": {
+      "fields": {
+        "Success 200": [{
+            "group": "Success 200",
+            "type": "string",
+            "optional": false,
+            "field": "message",
+            "description": "<p>Success message</p>"
+          },
+          {
+            "group": "Success 200",
+            "type": "object",
+            "optional": false,
+            "field": "data",
+            "description": "<p>empty</p>"
+          }
+        ]
+      },
+      "examples": [{
+        "title": "Success-Response: ",
+        "content": "{\"message\": \"Successfully logged out\", \"data\": {}}",
+        "type": "object"
+      }]
+    },
+    "permission": [{
+      "name": ": public"
+    }],
+    "filename": "routes/api/auth.js",
+    "groupTitle": "Authentication",
+    "sampleRequest": [{
+      "url": "https://mchacks.ca/api/auth/logout"
+    }]
+  },
+  {
+    "type": "get",
+    "url": "/auth/confirm/resend",
+    "title": "resend confirmation token",
+    "name": "resendConfirmAccount",
+    "group": "Authentication",
+    "version": "0.0.8",
+    "success": {
+      "fields": {
+        "Success 200": [{
+            "group": "Success 200",
+            "type": "string",
+            "optional": false,
+            "field": "message",
+            "description": "<p>Success message</p>"
+          },
+          {
+            "group": "Success 200",
+            "type": "object",
+            "optional": false,
+            "field": "data",
+            "description": "<p>empty</p>"
+          }
+        ]
+      },
+      "examples": [{
+        "title": "Success-Response:",
+        "content": "{\"message\": \"Successfully resent confirmation email\", \"data\": {}}",
+        "type": "json"
+      }]
+    },
+    "error": {
+      "fields": {
+        "Error 4xx": [{
+            "group": "Error 4xx",
+            "type": "string",
+            "optional": false,
+            "field": "message",
+            "description": "<p>Error message</p>"
+          },
+          {
+            "group": "Error 4xx",
+            "type": "object",
+            "optional": false,
+            "field": "data",
+            "description": "<p>empty</p>"
+          }
+        ]
+      },
+      "examples": [{
+          "title": "Error-Response:",
+          "content": " HTTP/1.1 422\n{\"message\": \"Account already confirmed, \"data\": {}}",
+          "type": "json"
+        },
+        {
+          "title": "Error-Response:",
+          "content": " HTTP/1.1 428\n{\"message\": \"Account already confirmed, \"data\": {}}",
+          "type": "json"
+        }
+      ]
+    },
+    "filename": "routes/api/auth.js",
+    "groupTitle": "Authentication",
+    "sampleRequest": [{
+      "url": "https://mchacks.ca/api/auth/confirm/resend"
+    }]
+  },
+  {
+    "type": "post",
+    "url": "/auth/password/reset",
+    "title": "reset password",
+    "name": "resetPassword",
+    "group": "Authentication",
+    "version": "0.0.8",
+    "parameter": {
+      "fields": {
+        "Parameter": [{
+          "group": "Parameter",
+          "type": "String",
+          "optional": false,
+          "field": "password",
+          "description": "<p>the password of the account</p>"
+        }]
+      },
+      "examples": [{
+        "title": "Request-Example:",
+        "content": "{ \"password\": \"hunter2\" }",
+        "type": "json"
+      }]
+    },
+    "header": {
+      "fields": {
+        "Header": [{
+          "group": "Header",
+          "type": "String",
+          "optional": false,
+          "field": "Authentication",
+          "description": "<p>the token that was provided in the reset password email</p>"
+        }]
+      },
+      "examples": [{
+        "title": "Header-Example:",
+        "content": "{\n  \"X-Reset-Token\": \"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c\"\n}",
+        "type": "json"
+      }]
+    },
+    "success": {
+      "fields": {
+        "Success 200": [{
+            "group": "Success 200",
+            "type": "string",
+            "optional": false,
+            "field": "message",
+            "description": "<p>Success message</p>"
+          },
+          {
+            "group": "Success 200",
+            "type": "object",
+            "optional": false,
+            "field": "data",
+            "description": "<p>empty</p>"
+          }
+        ]
+      },
+      "examples": [{
+        "title": "Success-Response: ",
+        "content": "{\"message\": \"Successfully reset password\", \"data\": {}}",
+        "type": "json"
+      }]
+    },
+    "permission": [{
+      "name": ": must have authentication token"
+    }],
+    "filename": "routes/api/auth.js",
+    "groupTitle": "Authentication",
+    "sampleRequest": [{
+      "url": "https://mchacks.ca/api/auth/password/reset"
+    }]
+  },
+  {
+    "type": "get",
+    "url": "/auth/rolebindings/:id",
+    "title": "retrieve rolebindings for a user given by their user id :id",
+    "name": "getRoleBindings",
+    "group": "Auth",
+    "version": "0.0.8",
+    "parameter": {
+      "fields": {
+        "param": [{
+          "group": "param",
+          "type": "ObjectId",
+          "optional": false,
+          "field": "id",
+          "description": "<p>MongoId of an account</p>"
+        }]
+      }
+    },
+    "success": {
+      "fields": {
+        "Success 200": [{
+            "group": "Success 200",
+            "type": "string",
+            "optional": false,
+            "field": "message",
+            "description": "<p>Success message</p>"
+          },
+          {
+            "group": "Success 200",
+            "type": "object",
+            "optional": false,
+            "field": "data",
+            "description": "<p>Rolebindings object</p>"
+          }
+        ]
+      },
+      "examples": [{
+        "title": "Success-Response: ",
+        "content": "{\n               \"message\": \"Successfully retrieved role bindings\",\n               \"data\": {\n                   accountId:\"5beca4ab2e069a34f91697b2\"\n                   id:\"5beca4ae2e069a34f91698b1\"\n                   roles: [\n                       {\n                           _id:\"5beca4ab2e069a34f91697d9\",\n                           name:\"hacker\",\n                           routes: [\n                               0:Object {_id: \"5beca4ae2e069a34f9169852\", requestType: \"POST\", uri: \"/api/auth/login\"},\n                               1:Object {_id: \"5beca4ae2e069a34f9169851\", requestType: \"POST\", uri: \"/api/auth/logout\"},\n                               2:Object {_id: \"5beca4ae2e069a34f9169850\", requestType: \"GET\", uri: \"/api/auth/rolebindings/:self\"},\n                               3:Object {_id: \"5beca4ae2e069a34f916984f\", requestType: \"GET\", uri: \"/api/account/self\"},\n                               4:Object {_id: \"5beca4ae2e069a34f916984e\", requestType: \"GET\", uri: \"/api/account/:self\"},\n                               5:Object {_id: \"5beca4ae2e069a34f916984d\", requestType: \"PATCH\", uri: \"/api/account/:self\"},\n                               6:Object {_id: \"5beca4ae2e069a34f916984c\", requestType: \"POST\", uri: \"/api/hacker/\"},\n                               7:Object {_id: \"5beca4ae2e069a34f916984b\", requestType: \"GET\", uri: \"/api/hacker/:self\"},\n                               8:Object {_id: \"5beca4ae2e069a34f916984a\", requestType: \"GET\", uri: \"/api/hacker/:self/resume\"},\n                               9:Object {_id: \"5beca4ae2e069a34f9169849\", requestType: \"PATCH\", uri: \"/api/hacker/:self\"}\n                           ]\n                       }\n                   ]\n               }\n           }",
+        "type": "object"
+      }]
+    },
+    "error": {
+      "fields": {
+        "Error 4xx": [{
+            "group": "Error 4xx",
+            "type": "string",
+            "optional": false,
+            "field": "message",
+            "description": "<p>Error message</p>"
+          },
+          {
+            "group": "Error 4xx",
+            "type": "object",
+            "optional": false,
+            "field": "data",
+            "description": "<p>empty</p>"
+          }
+        ]
+      },
+      "examples": [{
+        "title": "Error-Response: ",
+        "content": "{\"message\": \"Role Bindings not found\", \"data\": {}}",
+        "type": "object"
+      }]
+    },
+    "filename": "routes/api/auth.js",
+    "groupTitle": "Auth",
+    "sampleRequest": [{
+      "url": "https://mchacks.ca/api/auth/rolebindings/:id"
+    }]
+  },
+  {
+    "type": "post",
+    "url": "/hacker/",
+    "title": "create a new hacker",
+    "name": "createHacker",
+    "group": "Hacker",
+    "version": "0.0.8",
+    "parameter": {
+      "fields": {
+        "body": [{
+            "group": "body",
+            "type": "MongoID",
+            "optional": false,
+            "field": "accountId",
+            "description": "<p>ObjectID of the respective account</p>"
+          },
+          {
+            "group": "body",
+            "type": "String",
+            "optional": false,
+            "field": "school",
+            "description": "<p>Name of the school the hacker goes to</p>"
+          },
+          {
+            "group": "body",
+            "type": "String",
+            "optional": false,
+            "field": "gender",
+            "description": "<p>Gender of the hacker</p>"
+          },
+          {
+            "group": "body",
+            "type": "Boolean",
+            "optional": false,
+            "field": "needsBus",
+            "description": "<p>Whether the hacker requires a bus for transportation</p>"
+          },
+          {
+            "group": "body",
+            "type": "Json",
+            "optional": false,
+            "field": "application",
+            "description": "<p>The hacker's application. Resume and jobInterest fields are required.</p>"
+          }
+        ]
+      },
+      "examples": [{
+        "title": "application: ",
+        "content": "{\n    \"portfolioURL\": {\n        \"resume\": \"...\"\n        \"github\": \"...\",\n        \"dropler\": \"...\",\n        \"personal\": \"...\",\n        \"linkedIn\": \"...\",\n        \"other\": \"...\"\n    },\n    \"jobInterest\": \"...\",\n    \"skills\": [\"CSS\", \"HTML\"],    \n    \"comments\": \"...\",\n    \"essay\": \"...\",\n    \"team\": [id1, id2],\n}",
+        "type": "Json"
+      }]
+    },
+    "success": {
+      "fields": {
+        "Success 200": [{
+            "group": "Success 200",
+            "type": "string",
+            "optional": false,
+            "field": "message",
+            "description": "<p>Success message</p>"
+          },
+          {
+            "group": "Success 200",
+            "type": "object",
+            "optional": false,
+            "field": "data",
+            "description": "<p>Hacker object</p>"
+          }
+        ]
+      },
+      "examples": [{
+        "title": "Success-Response: ",
+        "content": "{\n    \"message\": \"Hacker creation successful\", \n    \"data\": {...}\n}",
+        "type": "object"
+      }]
+    },
+    "error": {
+      "fields": {
+        "Error 4xx": [{
+            "group": "Error 4xx",
+            "type": "string",
+            "optional": false,
+            "field": "message",
+            "description": "<p>Error message</p>"
+          },
+          {
+            "group": "Error 4xx",
+            "type": "object",
+            "optional": false,
+            "field": "data",
+            "description": "<p>empty</p>"
+          }
+        ]
+      },
+      "examples": [{
+        "title": "Error-Response: ",
+        "content": "{\"message\": \"Error while creating hacker\", \"data\": {}}",
+        "type": "object"
+      }]
+    },
+    "filename": "routes/api/hacker.js",
+    "groupTitle": "Hacker",
+    "sampleRequest": [{
+      "url": "https://mchacks.ca/api/hacker/"
+    }]
+  },
+  {
+    "type": "get",
+    "url": "/hacker/:id",
+    "title": "get a hacker's information",
+    "name": "getHacker",
+    "group": "Hacker",
+    "version": "0.0.8",
+    "parameter": {
+      "fields": {
+        "param": [{
+          "group": "param",
+          "type": "String",
+          "optional": false,
+          "field": "id",
+          "description": "<p>a hacker's unique mongoID</p>"
+        }]
+      }
+    },
+    "success": {
+      "fields": {
+        "Success 200": [{
+            "group": "Success 200",
+            "type": "String",
+            "optional": false,
+            "field": "message",
+            "description": "<p>Success message</p>"
+          },
+          {
+            "group": "Success 200",
+            "type": "Object",
+            "optional": false,
+            "field": "data",
+            "description": "<p>Sponsor object</p>"
+          }
+        ]
+      },
+      "examples": [{
+        "title": "Success-Response: ",
+        "content": "{\n               \"message\": \"Successfully retrieved hacker information\", \n               \"data\": {...}\n           }",
+        "type": "object"
+      }]
+    },
+    "error": {
+      "fields": {
+        "Error 4xx": [{
+            "group": "Error 4xx",
+            "type": "String",
+            "optional": false,
+            "field": "message",
+            "description": "<p>Error message</p>"
+          },
+          {
+            "group": "Error 4xx",
+            "type": "Object",
+            "optional": false,
+            "field": "data",
+            "description": "<p>empty</p>"
+          }
+        ]
+      },
+      "examples": [{
+        "title": "Error-Response: ",
+        "content": "{\"message\": \"Hacker not found\", \"data\": {}}",
+        "type": "object"
+      }]
+    },
+    "filename": "routes/api/hacker.js",
+    "groupTitle": "Hacker",
+    "sampleRequest": [{
+      "url": "https://mchacks.ca/api/hacker/:id"
+    }]
+  },
+  {
+    "type": "get",
+    "url": "/hacker/resume:id",
+    "title": "get the resume for a hacker.",
+    "name": "getHackerResume",
+    "group": "Hacker",
+    "version": "0.0.8",
+    "parameter": {
+      "fields": {
+        "param": [{
+          "group": "param",
+          "type": "ObjectId",
+          "optional": false,
+          "field": "id",
+          "description": "<p>Hacker id</p>"
+        }]
+      }
+    },
+    "success": {
+      "fields": {
+        "Success 200": [{
+          "group": "Success 200",
+          "type": "String",
+          "optional": false,
+          "field": "message",
+          "description": "<p>Success message</p>"
+        }]
+      },
+      "examples": [{
+        "title": "Success-Response:",
+        "content": "HTTP/1.1 200 OK \n{ \n    message: \"Downloaded resume\", \n    data: { \n        id: \"507f191e810c19729de860ea\", \n        resume: [Buffer] \n    } \n}",
+        "type": "json"
+      }]
+    },
+    "error": {
+      "fields": {
+        "Error 4xx": [{
+          "group": "Error 4xx",
+          "type": "String",
+          "optional": false,
+          "field": "message",
+          "description": "<p>&quot;Resume does not exist&quot;</p>"
+        }]
+      },
+      "examples": [{
+        "title": "Error-Response:",
+        "content": "HTTP/1.1 404 \n{ \n    message: \"Resume not found\", \n    data: {} \n}",
+        "type": "json"
+      }]
+    },
+    "permission": [{
+      "name": "Must be logged in, and the account id must be linked to the hacker."
+    }],
+    "filename": "routes/api/hacker.js",
+    "groupTitle": "Hacker"
+  },
+  {
+    "type": "patch",
+    "url": "/hacker/:id",
+    "title": "update a hacker's information.",
+    "description": "<p>This route only contains the ability to update a subset of a hacker's information. If you want to update a status, you must have Admin priviledges and use PATCH /hacker/status/:id.</p>",
+    "name": "patchHacker",
+    "group": "Hacker",
+    "version": "0.0.8",
+    "parameter": {
+      "fields": {
+        "body": [{
+            "group": "body",
+            "type": "String",
+            "optional": true,
+            "field": "school",
+            "description": "<p>Name of the school the hacker goes to</p>"
+          },
+          {
+            "group": "body",
+            "type": "String",
+            "optional": true,
+            "field": "gender",
+            "description": "<p>Gender of the hacker</p>"
+          },
+          {
+            "group": "body",
+            "type": "Boolean",
+            "optional": true,
+            "field": "needsBus",
+            "description": "<p>Whether the hacker requires a bus for transportation</p>"
+          },
+          {
+            "group": "body",
+            "type": "Json",
+            "optional": true,
+            "field": "application",
+            "description": "<p>The hacker's application</p>"
+          }
+        ]
+      },
+      "examples": [{
+        "title": "application: ",
+        "content": "{\n    \"portfolioURL\": {\n        \"resume\": \"...\"\n        \"github\": \"...\",\n        \"dropler\": \"...\",\n        \"personal\": \"...\",\n        \"linkedIn\": \"...\",\n        \"other\": \"...\"\n    },\n    \"jobInterest\": \"...\",\n    \"skills\": [\"CSS\", \"HTML\"],    \n    \"comments\": \"...\",\n    \"essay\": \"...\",\n    \"team\": [id1, id2],\n}",
+        "type": "Json"
+      }]
+    },
+    "success": {
+      "fields": {
+        "Success 200": [{
+            "group": "Success 200",
+            "type": "string",
+            "optional": false,
+            "field": "message",
+            "description": "<p>Success message</p>"
+          },
+          {
+            "group": "Success 200",
+            "type": "object",
+            "optional": false,
+            "field": "data",
+            "description": "<p>Hacker object</p>"
+          }
+        ]
+      },
+      "examples": [{
+        "title": "Success-Response: ",
+        "content": "{\n    \"message\": \"Changed hacker information\", \n    \"data\": {...}\n}",
+        "type": "object"
+      }]
+    },
+    "error": {
+      "fields": {
+        "Error 4xx": [{
+            "group": "Error 4xx",
+            "type": "string",
+            "optional": false,
+            "field": "message",
+            "description": "<p>Error message</p>"
+          },
+          {
+            "group": "Error 4xx",
+            "type": "object",
+            "optional": false,
+            "field": "data",
+            "description": "<p>empty</p>"
+          }
+        ]
+      },
+      "examples": [{
+        "title": "Error-Response: ",
+        "content": "{\"message\": \"Error while updating hacker\", \"data\": {}}",
+        "type": "object"
+      }]
+    },
+    "filename": "routes/api/hacker.js",
+    "groupTitle": "Hacker",
+    "sampleRequest": [{
+      "url": "https://mchacks.ca/api/hacker/:id"
+    }]
+  },
+  {
+    "type": "patch",
+    "url": "/hacker/status/:id",
+    "title": "update a hacker's status",
+    "name": "patchHackerStatus",
+    "group": "Hacker",
+    "version": "0.0.9",
+    "parameter": {
+      "fields": {
+        "body": [{
+          "group": "body",
+          "type": "String",
+          "optional": true,
+          "field": "status",
+          "description": "<p>Status of the hacker's application</p>"
+        }]
+      }
+    },
+    "success": {
+      "fields": {
+        "Success 200": [{
+            "group": "Success 200",
+            "type": "string",
+            "optional": false,
+            "field": "message",
+            "description": "<p>Success message</p>"
+          },
+          {
+            "group": "Success 200",
+            "type": "object",
+            "optional": false,
+            "field": "data",
+            "description": "<p>Hacker object</p>"
+          }
+        ]
+      },
+      "examples": [{
+        "title": "Success-Response: ",
+        "content": "{\n    \"message\": \"Changed hacker information\", \n    \"data\": {\n        \"status\": \"accepted\"\n    }\n}",
+        "type": "object"
+      }]
+    },
+    "permission": [{
+      "name": "Administrator"
+    }],
+    "filename": "routes/api/hacker.js",
+    "groupTitle": "Hacker",
+    "sampleRequest": [{
+      "url": "https://mchacks.ca/api/hacker/status/:id"
+    }]
+  },
+  {
+    "type": "post",
+    "url": "/hacker/resume/:id",
+    "title": "upload or update resume for a hacker.",
+    "name": "postHackerResume",
+    "group": "Hacker",
+    "version": "0.0.8",
+    "description": "<p><b>NOTE: This must be sent via multipart/form-data POST request</b></p>",
+    "parameter": {
+      "fields": {
+        "param": [{
+          "group": "param",
+          "type": "ObjectId",
+          "optional": false,
+          "field": "id",
+          "description": "<p>Hacker id</p>"
+        }],
+        "body": [{
+          "group": "body",
+          "type": "File",
+          "optional": false,
+          "field": "resume",
+          "description": "<p>The uploaded file.</p>"
+        }]
+      }
+    },
+    "success": {
+      "fields": {
+        "Success 200": [{
+            "group": "Success 200",
+            "type": "String",
+            "optional": false,
+            "field": "message",
+            "description": "<p>Success message</p>"
+          },
+          {
+            "group": "Success 200",
+            "type": "Object",
+            "optional": false,
+            "field": "data",
+            "description": "<p>Location in the bucket that the file was stored.</p>"
+          }
+        ]
+      },
+      "examples": [{
+        "title": "Success-Response: ",
+        "content": "HTTP/1.1 200 OK\n{\n    message: \"Uploaded resume\", \n    data: {\n        filename: \"resumes/1535032624768-507f191e810c19729de860ea\"\n    }\n}",
+        "type": "json"
+      }]
+    },
+    "permission": [{
+      "name": "Must be logged in, and the account id must be linked to the hacker."
+    }],
+    "filename": "routes/api/hacker.js",
+    "groupTitle": "Hacker",
+    "sampleRequest": [{
+      "url": "https://mchacks.ca/api/hacker/resume/:id"
+    }]
+  },
+  {
+    "type": "get",
+    "url": "/",
+    "title": "version",
+    "version": "0.0.8",
+    "name": "index",
+    "group": "Index",
+    "permission": [{
+      "name": "public"
+    }],
+    "filename": "routes/index.js",
+    "groupTitle": "Index",
+    "sampleRequest": [{
+      "url": "https://mchacks.ca/api/"
+    }]
+  },
+  {
+    "type": "get",
+    "url": "/search/:model",
+    "title": "provide a specific query for any defined model",
+    "name": "search",
+    "group": "Search",
+    "version": "0.0.8",
+    "parameter": {
+      "fields": {
+        "param": [{
+          "group": "param",
+          "type": "String",
+          "optional": false,
+          "field": "model",
+          "description": "<p>the model to be searched</p>"
+        }],
+        "query": [{
+          "group": "query",
+          "type": "Array",
+          "optional": false,
+          "field": "q",
+          "description": "<p>the query to be executed. For more information on how to format this, please see https://hackerapi.mchacks.ca/architecture/</p>"
+        }]
+      }
+    },
+    "success": {
+      "fields": {
+        "Success 200": [{
+            "group": "Success 200",
+            "type": "String",
+            "optional": false,
+            "field": "message",
+            "description": "<p>Success message</p>"
+          },
+          {
+            "group": "Success 200",
+            "type": "Object",
+            "optional": false,
+            "field": "data",
+            "description": "<p>Results</p>"
+          }
+        ]
+      },
+      "examples": [{
+          "title": "Success-Response:",
+          "content": "{\n               \"message\": \"Successfully executed query, returning all results\",\n               \"data\": [\n                   {...}\n               ]\n           }",
+          "type": "object"
+        },
+        {
+          "title": "Success-Response:",
+          "content": "{\n               \"message\": \"No results found.\",\n               \"data\": {}\n           }",
+          "type": "object"
+        }
+      ]
+    },
+    "error": {
+      "fields": {
+        "Error 4xx": [{
+            "group": "Error 4xx",
+            "type": "String",
+            "optional": false,
+            "field": "message",
+            "description": "<p>Error message</p>"
+          },
+          {
+            "group": "Error 4xx",
+            "type": "Object",
+            "optional": false,
+            "field": "data",
+            "description": "<p>empty</p>"
+          }
+        ]
+      },
+      "examples": [{
+        "title": "Error-Response:",
+        "content": "{\"message\": \"Validation failed\", \"data\": {}}",
+        "type": "object"
+      }]
+    },
+    "filename": "routes/api/search.js",
+    "groupTitle": "Search",
+    "sampleRequest": [{
+      "url": "https://mchacks.ca/api/search/:model"
+    }]
+  },
+  {
+    "type": "post",
+    "url": "/sponsor/",
+    "title": "create a new sponsor",
+    "name": "createSponsor",
+    "group": "Sponsor",
+    "version": "0.0.8",
+    "parameter": {
+      "fields": {
+        "body": [{
+            "group": "body",
+            "type": "MongoID",
+            "optional": false,
+            "field": "accountId",
+            "description": "<p>ObjectID of the respective account.</p>"
+          },
+          {
+            "group": "body",
+            "type": "Number",
+            "optional": false,
+            "field": "tier",
+            "description": "<p>Tier of the sponsor, from 0 to 5. 0 is lowest tier, and 5 is the custom tier.</p>"
+          },
+          {
+            "group": "body",
+            "type": "String",
+            "optional": false,
+            "field": "company",
+            "description": "<p>Name of the company.</p>"
+          },
+          {
+            "group": "body",
+            "type": "String",
+            "optional": false,
+            "field": "contractURL",
+            "description": "<p>URL link to the contract with the company.</p>"
+          },
+          {
+            "group": "body",
+            "type": "MongoID[]",
+            "optional": false,
+            "field": "nominees",
+            "description": "<p>Array of accounts that the company wish to nominate as hackers.</p>"
+          }
+        ]
+      }
+    },
+    "success": {
+      "fields": {
+        "Success 200": [{
+            "group": "Success 200",
+            "type": "String",
+            "optional": false,
+            "field": "message",
+            "description": "<p>Success message</p>"
+          },
+          {
+            "group": "Success 200",
+            "type": "Object",
+            "optional": false,
+            "field": "data",
+            "description": "<p>Sponsor object</p>"
+          }
+        ]
+      },
+      "examples": [{
+        "title": "Success-Response: ",
+        "content": "{\n               \"message\": \"Sponsor creation successful\", \n               \"data\": {...}\n           }",
+        "type": "object"
+      }]
+    },
+    "error": {
+      "fields": {
+        "Error 4xx": [{
+            "group": "Error 4xx",
+            "type": "String",
+            "optional": false,
+            "field": "message",
+            "description": "<p>Error message</p>"
+          },
+          {
+            "group": "Error 4xx",
+            "type": "Object",
+            "optional": false,
+            "field": "data",
+            "description": "<p>empty</p>"
+          }
+        ]
+      },
+      "examples": [{
+        "title": "Error-Response: ",
+        "content": "{\"message\": \"Error while creating sponsor\", \"data\": {}}",
+        "type": "object"
+      }]
+    },
+    "filename": "routes/api/sponsor.js",
+    "groupTitle": "Sponsor",
+    "sampleRequest": [{
+      "url": "https://mchacks.ca/api/sponsor/"
+    }]
+  },
+  {
+    "type": "get",
+    "url": "/sponsor/:id",
+    "title": "get a sponsor's information",
+    "name": "getSponsor",
+    "group": "Sponsor",
+    "version": "0.0.8",
+    "parameter": {
+      "fields": {
+        "param": [{
+          "group": "param",
+          "type": "string",
+          "optional": false,
+          "field": "id",
+          "description": "<p>a sponsor's unique mongoID</p>"
+        }]
+      }
+    },
+    "success": {
+      "fields": {
+        "Success 200": [{
+            "group": "Success 200",
+            "type": "String",
+            "optional": false,
+            "field": "message",
+            "description": "<p>Success message</p>"
+          },
+          {
+            "group": "Success 200",
+            "type": "Object",
+            "optional": false,
+            "field": "data",
+            "description": "<p>Sponsor object</p>"
+          }
+        ]
+      },
+      "examples": [{
+        "title": "Success-Response: ",
+        "content": "{\n               \"message\": \"Successfully retrieved sponsor information\", \n               \"data\": {...}\n           }",
+        "type": "object"
+      }]
+    },
+    "error": {
+      "fields": {
+        "Error 4xx": [{
+            "group": "Error 4xx",
+            "type": "String",
+            "optional": false,
+            "field": "message",
+            "description": "<p>Error message</p>"
+          },
+          {
+            "group": "Error 4xx",
+            "type": "Object",
+            "optional": false,
+            "field": "data",
+            "description": "<p>empty</p>"
+          }
+        ]
+      },
+      "examples": [{
+        "title": "Error-Response: ",
+        "content": "{\"message\": \"Sponsor not found\", \"data\": {}}",
+        "type": "object"
+      }]
+    },
+    "filename": "routes/api/sponsor.js",
+    "groupTitle": "Sponsor",
+    "sampleRequest": [{
+      "url": "https://mchacks.ca/api/sponsor/:id"
+    }]
+  },
+  {
+    "type": "post",
+    "url": "/team/",
+    "title": "create a new team",
+    "name": "createTeam",
+    "group": "Team",
+    "version": "0.0.8",
+    "parameter": {
+      "fields": {
+        "body": [{
+            "group": "body",
+            "type": "String",
+            "optional": false,
+            "field": "name",
+            "description": "<p>Name of the team.</p>"
+          },
+          {
+            "group": "body",
+            "type": "MongoID[]",
+            "optional": true,
+            "field": "members",
+            "description": "<p>Array of members in team.</p>"
+          },
+          {
+            "group": "body",
+            "type": "String",
+            "optional": true,
+            "field": "devpostURL",
+            "description": "<p>Devpost link to hack. Once the link is sent, the hack will be considered to be submitted.</p>"
+          },
+          {
+            "group": "body",
+            "type": "String",
+            "optional": false,
+            "field": "projectName",
+            "description": "<p>Name of the team.</p>"
+          }
+        ]
+      }
+    },
+    "success": {
+      "fields": {
+        "Success 200": [{
+            "group": "Success 200",
+            "type": "string",
+            "optional": false,
+            "field": "message",
+            "description": "<p>Success message</p>"
+          },
+          {
+            "group": "Success 200",
+            "type": "object",
+            "optional": false,
+            "field": "data",
+            "description": "<p>Team object</p>"
+          }
+        ]
+      },
+      "examples": [{
+        "title": "Success-Response: ",
+        "content": "{\n               \"message\": \"Team creation successful\", \n               \"data\": {...}\n           }",
+        "type": "object"
+      }]
+    },
+    "error": {
+      "fields": {
+        "Error 4xx": [{
+            "group": "Error 4xx",
+            "type": "string",
+            "optional": false,
+            "field": "message",
+            "description": "<p>Error message</p>"
+          },
+          {
+            "group": "Error 4xx",
+            "type": "object",
+            "optional": false,
+            "field": "data",
+            "description": "<p>empty</p>"
+          }
+        ]
+      },
+      "examples": [{
+        "title": "Error-Response: ",
+        "content": "{\"message\": \"Error while creating team\", \"data\": {}}",
+        "type": "object"
+      }]
+    },
+    "filename": "routes/api/team.js",
+    "groupTitle": "Team",
+    "sampleRequest": [{
+      "url": "https://mchacks.ca/api/team/"
+    }]
+  },
+  {
+    "type": "get",
+    "url": "/team/:id",
+    "title": "get a team's information",
+    "name": "getTeam",
+    "group": "Team",
+    "version": "0.0.8",
+    "parameter": {
+      "fields": {
+        "param": [{
+          "group": "param",
+          "type": "ObjectId",
+          "optional": false,
+          "field": "id",
+          "description": "<p>a team's unique mongoId</p>"
+        }]
+      }
+    },
+    "success": {
+      "fields": {
+        "Success 200": [{
+            "group": "Success 200",
+            "type": "String",
+            "optional": false,
+            "field": "message",
+            "description": "<p>Success message</p>"
+          },
+          {
+            "group": "Success 200",
+            "type": "Object",
+            "optional": false,
+            "field": "data",
+            "description": "<p>Sponsor object</p>"
+          }
+        ]
+      },
+      "examples": [{
+        "title": "Success-Response: ",
+        "content": "{\n               \"message\": \"Successfully retrieved team information\", \n               \"data\": {...}\n           }",
+        "type": "object"
+      }]
+    },
+    "error": {
+      "fields": {
+        "Error 4xx": [{
+            "group": "Error 4xx",
+            "type": "String",
+            "optional": false,
+            "field": "message",
+            "description": "<p>Error message</p>"
+          },
+          {
+            "group": "Error 4xx",
+            "type": "Object",
+            "optional": false,
+            "field": "data",
+            "description": "<p>empty</p>"
+          }
+        ]
+      },
+      "examples": [{
+        "title": "Error-Response: ",
+        "content": "{\"message\": \"Team not found\", \"data\": {}}",
+        "type": "object"
+      }]
+    },
+    "filename": "routes/api/team.js",
+    "groupTitle": "Team",
+    "sampleRequest": [{
+      "url": "https://mchacks.ca/api/team/:id"
+    }]
+  },
+  {
+    "type": "post",
+    "url": "/volunteer/",
+    "title": "create a new volunteer",
+    "name": "createVolunteer",
+    "group": "Volunteer",
+    "version": "0.0.8",
+    "parameter": {
+      "fields": {
+        "body": [{
+          "group": "body",
+          "type": "MongoID",
+          "optional": false,
+          "field": "accountId",
+          "description": "<p>MongoID of the account of the volunteer</p>"
+        }]
+      }
+    },
+    "success": {
+      "fields": {
+        "Success 200": [{
+            "group": "Success 200",
+            "type": "string",
+            "optional": false,
+            "field": "message",
+            "description": "<p>Success message</p>"
+          },
+          {
+            "group": "Success 200",
+            "type": "object",
+            "optional": false,
+            "field": "data",
+            "description": "<p>Volunteer object</p>"
+          }
+        ]
+      },
+      "examples": [{
+        "title": "Success-Response: ",
+        "content": "{\n               \"message\": \"Volunteer creation successful\", \n               \"data\": {...}\n           }",
+        "type": "object"
+      }]
+    },
+    "error": {
+      "fields": {
+        "Error 4xx": [{
+            "group": "Error 4xx",
+            "type": "string",
+            "optional": false,
+            "field": "message",
+            "description": "<p>Error message</p>"
+          },
+          {
+            "group": "Error 4xx",
+            "type": "object",
+            "optional": false,
+            "field": "data",
+            "description": "<p>empty</p>"
+          }
+        ]
+      },
+      "examples": [{
+        "title": "Error-Response: ",
+        "content": "{\"message\": \"Error while creating volunteer\", \"data\": {}}",
+        "type": "object"
+      }]
+    },
+    "filename": "routes/api/volunteer.js",
+    "groupTitle": "Volunteer",
+    "sampleRequest": [{
+      "url": "https://mchacks.ca/api/volunteer/"
+    }]
+  }
+]

--- a/docs/api/api_project.js
+++ b/docs/api/api_project.js
@@ -9,7 +9,7 @@ define({
   "apidoc": "0.3.0",
   "generator": {
     "name": "apidoc",
-    "time": "2018-11-23T00:28:56.023Z",
+    "time": "2018-11-23T00:32:38.303Z",
     "url": "http://apidocjs.com",
     "version": "0.17.6"
   }

--- a/docs/api/api_project.js
+++ b/docs/api/api_project.js
@@ -1,16 +1,1 @@
-define({
-  "name": "hackerAPI",
-  "version": "0.0.8",
-  "description": "Documentation for the API used for mchacks",
-  "defaultVersion": "0.0.8",
-  "title": "hackerAPI documentation",
-  "url": "https://mchacks.ca/api",
-  "sampleUrl": "https://mchacks.ca/api",
-  "apidoc": "0.3.0",
-  "generator": {
-    "name": "apidoc",
-    "time": "2018-11-21T04:02:20.539Z",
-    "url": "http://apidocjs.com",
-    "version": "0.17.6"
-  }
-});
+define({  "name": "hackerAPI",  "version": "0.0.8",  "description": "Documentation for the API used for mchacks",  "defaultVersion": "0.0.8",  "title": "hackerAPI documentation",  "url": "https://mchacks.ca/api",  "sampleUrl": "https://mchacks.ca/api",  "apidoc": "0.3.0",  "generator": {    "name": "apidoc",    "time": "2018-11-23T00:28:56.023Z",    "url": "http://apidocjs.com",    "version": "0.17.6"  }});

--- a/docs/api/api_project.js
+++ b/docs/api/api_project.js
@@ -1,1 +1,16 @@
-define({  "name": "hackerAPI",  "version": "0.0.8",  "description": "Documentation for the API used for mchacks",  "defaultVersion": "0.0.8",  "title": "hackerAPI documentation",  "url": "https://mchacks.ca/api",  "sampleUrl": "https://mchacks.ca/api",  "apidoc": "0.3.0",  "generator": {    "name": "apidoc",    "time": "2018-11-23T00:28:56.023Z",    "url": "http://apidocjs.com",    "version": "0.17.6"  }});
+define({
+  "name": "hackerAPI",
+  "version": "0.0.8",
+  "description": "Documentation for the API used for mchacks",
+  "defaultVersion": "0.0.8",
+  "title": "hackerAPI documentation",
+  "url": "https://mchacks.ca/api",
+  "sampleUrl": "https://mchacks.ca/api",
+  "apidoc": "0.3.0",
+  "generator": {
+    "name": "apidoc",
+    "time": "2018-11-23T00:28:56.023Z",
+    "url": "http://apidocjs.com",
+    "version": "0.17.6"
+  }
+});

--- a/docs/api/api_project.json
+++ b/docs/api/api_project.json
@@ -1,1 +1,16 @@
-{  "name": "hackerAPI",  "version": "0.0.8",  "description": "Documentation for the API used for mchacks",  "defaultVersion": "0.0.8",  "title": "hackerAPI documentation",  "url": "https://mchacks.ca/api",  "sampleUrl": "https://mchacks.ca/api",  "apidoc": "0.3.0",  "generator": {    "name": "apidoc",    "time": "2018-11-23T00:28:56.023Z",    "url": "http://apidocjs.com",    "version": "0.17.6"  }}
+{
+  "name": "hackerAPI",
+  "version": "0.0.8",
+  "description": "Documentation for the API used for mchacks",
+  "defaultVersion": "0.0.8",
+  "title": "hackerAPI documentation",
+  "url": "https://mchacks.ca/api",
+  "sampleUrl": "https://mchacks.ca/api",
+  "apidoc": "0.3.0",
+  "generator": {
+    "name": "apidoc",
+    "time": "2018-11-23T00:28:56.023Z",
+    "url": "http://apidocjs.com",
+    "version": "0.17.6"
+  }
+}

--- a/docs/api/api_project.json
+++ b/docs/api/api_project.json
@@ -1,16 +1,1 @@
-{
-  "name": "hackerAPI",
-  "version": "0.0.8",
-  "description": "Documentation for the API used for mchacks",
-  "defaultVersion": "0.0.8",
-  "title": "hackerAPI documentation",
-  "url": "https://mchacks.ca/api",
-  "sampleUrl": "https://mchacks.ca/api",
-  "apidoc": "0.3.0",
-  "generator": {
-    "name": "apidoc",
-    "time": "2018-11-21T04:02:20.539Z",
-    "url": "http://apidocjs.com",
-    "version": "0.17.6"
-  }
-}
+{  "name": "hackerAPI",  "version": "0.0.8",  "description": "Documentation for the API used for mchacks",  "defaultVersion": "0.0.8",  "title": "hackerAPI documentation",  "url": "https://mchacks.ca/api",  "sampleUrl": "https://mchacks.ca/api",  "apidoc": "0.3.0",  "generator": {    "name": "apidoc",    "time": "2018-11-23T00:28:56.023Z",    "url": "http://apidocjs.com",    "version": "0.17.6"  }}

--- a/docs/api/api_project.json
+++ b/docs/api/api_project.json
@@ -9,7 +9,7 @@
   "apidoc": "0.3.0",
   "generator": {
     "name": "apidoc",
-    "time": "2018-11-23T00:28:56.023Z",
+    "time": "2018-11-23T00:32:38.303Z",
     "url": "http://apidocjs.com",
     "version": "0.17.6"
   }

--- a/middlewares/auth.middleware.js
+++ b/middlewares/auth.middleware.js
@@ -38,7 +38,7 @@ function login(req, res, next) {
                     error: {}
                 });
             }
-            req.login(user, loginErr => {
+            req.login(user, (loginErr) => {
                 if (loginErr) {
                     return next({
                         status: 500,

--- a/middlewares/auth.middleware.js
+++ b/middlewares/auth.middleware.js
@@ -21,6 +21,13 @@ const Constants = {
     Error: require("../constants/error.constant"),
 };
 
+/**
+ * @param {*} req
+ * @param {*} res
+ * @param {(err?)=>void} next 
+ * Calls passport.authenticate with a custom error handler. Errors during authentication will return res with a generic 500 error, 
+ * Failed authentication returns a AUTH 401 error, and errors during login will return res with a LOGIN 500 error.
+ */
 function login(req, res, next) {
     passport.authenticate("emailAndPass",
         function (err, user) {

--- a/routes/api/auth.js
+++ b/routes/api/auth.js
@@ -41,7 +41,7 @@ module.exports = {
          * @apiError {string} message Error message
          * @apiError {object} data empty
          * @apiErrorExample {object} Error-Response: 
-         *      {"message": "Invalid email or password", "data": {}}
+         *      {"message": "Invalid Authentication", "data": {}}
          * 
          * @apiPermission: public
          */

--- a/routes/api/auth.js
+++ b/routes/api/auth.js
@@ -46,7 +46,7 @@ module.exports = {
          * @apiPermission: public
          */
         authRouter.route("/login").post(
-            passport.authenticate("emailAndPass"),
+            Middleware.Auth.login,
             Controllers.Auth.onSuccessfulLogin
         );
 

--- a/services/auth.service.js
+++ b/services/auth.service.js
@@ -15,7 +15,7 @@ module.exports = {
                 if (!!account) {
                     done(null, account);
                 } else {
-                    done("Invalid email or password.", false);
+                    done(null, false);
                 }
             },
             (reason) => {

--- a/tests/account.test.js
+++ b/tests/account.test.js
@@ -45,6 +45,19 @@ describe("GET user account", function () {
             });
     });
 
+    // fail due to invalid login
+    it("should fail due to invalid password", function (done) {
+        agent.post("/api/auth/login").type("application/json").send({
+            email: Admin1.email,
+            password: "FakePassword"
+        }).end((err, res) => {
+            res.should.have.status(401);
+            res.body.should.have.property("message");
+            res.body.message.should.equal(Constants.Error.AUTH_401_MESSAGE);
+            done();
+        });
+    });
+
     // success case
     it("should list the user's account on /api/account/self GET", function (done) {
         util.auth.login(agent, Admin1, (error) => {
@@ -68,8 +81,6 @@ describe("GET user account", function () {
                     res.body.data.should.have.property("firstName");
                     res.body.data.should.have.property("lastName");
                     res.body.data.should.have.property("email");
-                    // ???
-                    // res.body.data.should.equal(req.user.email);
                     res.body.data.should.have.property("dietaryRestrictions");
                     res.body.data.should.have.property("shirtSize");
                     done();

--- a/tests/storage.spec.js
+++ b/tests/storage.spec.js
@@ -9,7 +9,7 @@ const assert = require("chai").assert;
 
 var fs = require("fs");
 
-describe("Storage service", function() {
+describe("Storage service", function () {
     this.timeout(0);
     const file = {
         mimetype: "application/pdf",
@@ -40,7 +40,7 @@ describe("Storage service", function() {
                         assert.isFalse(exists[0]);
                         done();
                     }
-                ).catch(done);    
+                ).catch(done);
             }
         ).catch(done);
     });

--- a/tests/team.test.js
+++ b/tests/team.test.js
@@ -10,40 +10,40 @@ const util = {
 };
 
 describe("GET team", function () {
-    it("should SUCCEED and list a team's information from /api/team/:id GET", function(done) {
+    it("should SUCCEED and list a team's information from /api/team/:id GET", function (done) {
         chai.request(server.app)
-        .get(`/api/team/` + util.team.Team1._id)
-        .end(function (err, res) {
-            res.should.have.status(200);
-            res.should.be.json;
-            res.body.should.have.property("message");
-            res.body.message.should.equal("Successfully retrieved team information");
-            res.body.should.have.property("data");
+            .get(`/api/team/` + util.team.Team1._id)
+            .end(function (err, res) {
+                res.should.have.status(200);
+                res.should.be.json;
+                res.body.should.have.property("message");
+                res.body.message.should.equal("Successfully retrieved team information");
+                res.body.should.have.property("data");
 
-            let team = new Team(util.team.Team1);
-            chai.assert.equal(JSON.stringify(res.body.data), JSON.stringify(team.toJSON()));
-            done();
-        });
+                let team = new Team(util.team.Team1);
+                chai.assert.equal(JSON.stringify(res.body.data), JSON.stringify(team.toJSON()));
+                done();
+            });
     });
 });
 
 describe("POST create team", function () {
-    it("should SUCCEED and create a new team", function(done) {
+    it("should SUCCEED and create a new team", function (done) {
         chai.request(server.app)
-        .post(`/api/team/`)
-        .type("application/json")
-        .send(util.team.newTeam1)
-        .end(function (err, res) {
-            res.should.have.status(200);
-            res.should.be.json;
-            res.body.should.have.property("message");
-            res.body.message.should.equal("Team creation successful");
-            res.body.should.have.property("data");
+            .post(`/api/team/`)
+            .type("application/json")
+            .send(util.team.newTeam1)
+            .end(function (err, res) {
+                res.should.have.status(200);
+                res.should.be.json;
+                res.body.should.have.property("message");
+                res.body.message.should.equal("Team creation successful");
+                res.body.should.have.property("data");
 
-            // deleting _id because that was generated, and not part of original data
-            delete res.body.data._id;
-            chai.assert.equal(JSON.stringify(res.body.data), JSON.stringify(util.team.newTeam1));
-            done();
-        });
+                // deleting _id because that was generated, and not part of original data
+                delete res.body.data._id;
+                chai.assert.equal(JSON.stringify(res.body.data), JSON.stringify(util.team.newTeam1));
+                done();
+            });
     });
 });

--- a/tests/util/auth.test.util.js
+++ b/tests/util/auth.test.util.js
@@ -16,7 +16,7 @@ function login(agent, credentials, callback) {
             email: credentials.email,
             password: credentials.password
         }).end((err, res) => {
-            if(err) {
+            if (err) {
                 callback(err);
             } else {
                 callback();


### PR DESCRIPTION
# Description

Added a middleware wrapper around passport to add a custom error handler in case of invalid login, and errors while logging in. Invalid account/password now gives an error 401 with respective auth 401 error.

Fixes #150

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Added a test to auth.test for the case where the password does not match the email.
