### PR TITLE
Fix links

### DIFF
--- a/assets/email/AccountConfirmation.hbs
+++ b/assets/email/AccountConfirmation.hbs
@@ -413,12 +413,13 @@
                                             <p>
                                                 Hi {{firstName}},
                                                 <br><br>
-                                                To start your McHacks 6 application, we first need to confirm your email.
+                                                To start your McHacks 6 application, we first need to confirm your
+                                                email.
                                                 <br><br>
                                                 Get that sorted by clicking below!
                                             </p>
                                             <div class="center">
-                                                <a href="{{link}}" class="button">
+                                                <a href="{{{link}}}" class="button">
                                                     Confirm your email
                                                 </a>
                                             </div>
@@ -461,6 +462,6 @@
             </tr>
         </table>
     </center>
-    </body>
+</body>
 
 </html>

--- a/assets/email/AccountInvitation.hbs
+++ b/assets/email/AccountInvitation.hbs
@@ -418,12 +418,15 @@
                                                 Click the button below to get things started!
                                             </p>
                                             <div class="center">
-                                                <a href="{{link}}" class="button">
+                                                <a href="{{{link}}}" class="button">
                                                     Create my account
                                                 </a>
                                             </div>
                                             <p>
-                                                In the meantime, follow us on <a href="https://facebook.com/mcgillhacks">Facebook</a>, <a href="https://twitter.com/mcgillhacks">Twitter</a>, and <a href="https://instagram.com/mcgillhacks">Instagram</a> for important updates and news about McHacks 6! If you have any questions, feel free to reach out at <a href="mailto:contact@mchacks.ca">contact@mchacks.ca</a>.
+                                                In the meantime, follow us on <a href="https://facebook.com/mcgillhacks">Facebook</a>,
+                                                <a href="https://twitter.com/mcgillhacks">Twitter</a>, and <a href="https://instagram.com/mcgillhacks">Instagram</a>
+                                                for important updates and news about McHacks 6! If you have any
+                                                questions, feel free to reach out at <a href="mailto:contact@mchacks.ca">contact@mchacks.ca</a>.
                                             </p>
                                             <p>
                                                 <br>
@@ -464,6 +467,6 @@
             </tr>
         </table>
     </center>
-    </body>
+</body>
 
 </html>

--- a/assets/email/ResetPassword.hbs
+++ b/assets/email/ResetPassword.hbs
@@ -413,12 +413,14 @@
                                             <p>
                                                 Hi {{firstName}},
                                                 <br><br>
-                                                Looks like you forgot your password. That's okay, it happens now and then!
+                                                Looks like you forgot your password. That's okay, it happens now and
+                                                then!
                                                 <br><br>
-                                                Click the button below to get things started again. It will lead you to a page where you can reset your password.
+                                                Click the button below to get things started again. It will lead you to
+                                                a page where you can reset your password.
                                             </p>
                                             <div class="center">
-                                                <a href="{{link}}" class="button">
+                                                <a href="{{{link}}}" class="button">
                                                     Reset my password
                                                 </a>
                                             </div>
@@ -461,6 +463,6 @@
             </tr>
         </table>
     </center>
-    </body>
+</body>
 
 </html>

--- a/assets/email/statusEmail/Accepted.hbs
+++ b/assets/email/statusEmail/Accepted.hbs
@@ -413,23 +413,33 @@
                                             <p>
                                                 Congratulations, {{firstName}}! 🎉
                                                 <br><br>
-                                                We are thrilled to invite you as a hacker at McHacks 6! We can't wait to see what you dream, develop, and deploy within 24 hours on February 2-3, 2019.
+                                                We are thrilled to invite you as a hacker at McHacks 6! We can't wait
+                                                to see what you dream, develop, and deploy within 24 hours on February
+                                                2-3, 2019.
                                                 <br><br>
                                                 Here are your next steps:
                                                 <br><br>
-                                                <li>Confirm your attendance on our hacker dashboard no later than (date)</li>
+                                                <li>Confirm your attendance on our hacker dashboard no later than
+                                                    (date)</li>
                                                 <li>Join our FB group to mingle with other hackers coming to McHacks 6</li>
                                                 <br><br>
-                                                We've received an overwhelming number of applicants this year for only 600 spots. If you can no longer attend McHacks 6, please let us know by withdrawing your application on our <a href="https://app.mchacks.ca/">hacker dashboard</a> so we can pass your spot along to someone who is on the waitlist.
+                                                We've received an overwhelming number of applicants this year for only
+                                                600 spots. If you can no longer attend McHacks 6, please let us know by
+                                                withdrawing your application on our <a href="https://app.mchacks.ca/">hacker
+                                                    dashboard</a> so we can pass your spot along to someone who is on
+                                                the waitlist.
                                             </p>
                                             <div class="center">
-                                                <a href="{{link}}" class="button">
+                                                <a href="{{{link}}}" class="button">
                                                     RSVP
                                                 </a>
                                             </div>
                                             <p>
                                                 <br>
-                                                In the meantime, follow us on <a href="https://facebook.com/mcgillhacks">Facebook</a>, <a href="https://twitter.com/mcgillhacks">Twitter</a>, and <a href="https://instagram.com/mcgillhacks">Instagram</a> for important updates and news about McHacks 6! If you have any questions, feel free to reach out at <a href="mailto:contact@mchacks.ca">contact@mchacks.ca</a>.
+                                                In the meantime, follow us on <a href="https://facebook.com/mcgillhacks">Facebook</a>,
+                                                <a href="https://twitter.com/mcgillhacks">Twitter</a>, and <a href="https://instagram.com/mcgillhacks">Instagram</a>
+                                                for important updates and news about McHacks 6! If you have any
+                                                questions, feel free to reach out at <a href="mailto:contact@mchacks.ca">contact@mchacks.ca</a>.
                                             </p>
                                             <p>
                                                 <br>
@@ -470,6 +480,6 @@
             </tr>
         </table>
     </center>
-    </body>
+</body>
 
 </html>


### PR DESCRIPTION
Make sure that you template links as `{{{link}}}`, not `{{link}}`, so that query parameters are not escaped.