### PR TITLE
Fix duplicate email bug

### DIFF
--- a/constants/error.constant.js
+++ b/constants/error.constant.js
@@ -9,6 +9,7 @@ const VOLUNTEER_404_MESSAGE = "Volunteer not found";
 const SETTINGS_404_MESSAGE = "Settings not found";
 
 const ACCOUNT_TYPE_409_MESSAGE = "Wrong account type";
+const ACCOUNT_EMAIL_409_MESSAGE = "Email already in use";
 const SPONSOR_ID_409_MESSAGE = "Conflict with sponsor accountId link";
 const VOLUNTEER_ID_409_MESSAGE = "Conflict with volunteer accountId link";
 const HACKER_ID_409_MESSAGE = "Conflict with hacker accountId link";
@@ -50,6 +51,7 @@ module.exports = {
     TEAM_404_MESSAGE: TEAM_404_MESSAGE,
     RESUME_404_MESSAGE: RESUME_404_MESSAGE,
     ACCOUNT_TYPE_409_MESSAGE: ACCOUNT_TYPE_409_MESSAGE,
+    ACCOUNT_EMAIL_409_MESSAGE: ACCOUNT_EMAIL_409_MESSAGE,
     SPONSOR_ID_409_MESSAGE: SPONSOR_ID_409_MESSAGE,
     VOLUNTEER_ID_409_MESSAGE: VOLUNTEER_ID_409_MESSAGE,
     TEAM_MEMBER_409_MESSAGE: TEAM_MEMBER_409_MESSAGE,

--- a/middlewares/account.middleware.js
+++ b/middlewares/account.middleware.js
@@ -168,7 +168,17 @@ async function updateAccount(req, res, next) {
     // If we are changing the email, and there is a difference between the two, set back to unconfirmed status.
     // TODO: When pull request for parse patch refactor #546 hits, req.body.email will not be present.
     if (req.body.email && account.email != req.body.email) {
-        req.body.confirmed = false;
+        const existingAccount = await Services.Account.findByEmail(
+            account.email
+        );
+        if (existingAccount) {
+            return next({
+                status: 409,
+                message: Constants.Error.ACCOUNT_EMAIL_409_MESSAGE
+            });
+        } else {
+            req.body.confirmed = false;
+        }
     }
 
     req.body.account = await Services.Account.updateOne(

--- a/package-lock.json
+++ b/package-lock.json
@@ -5457,11 +5457,6 @@
       "resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-4.5.0.tgz",
       "integrity": "sha1-GVhwRQ9aExkkeN9Lw9I9LeoZB7Y="
     },
-    "lodash.clonedeep": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
-    },
     "lodash.has": {
       "version": "4.5.2",
       "resolved": "https://registry.npmjs.org/lodash.has/-/lodash.has-4.5.2.tgz",
@@ -6288,11 +6283,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
-    },
-    "nvm": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/nvm/-/nvm-0.0.4.tgz",
-      "integrity": "sha1-OKF46dMbKDUIyS0VydqGHRqSELw="
     },
     "oauth-sign": {
       "version": "0.9.0",


### PR DESCRIPTION
### Tickets:

[HCK-185](https://hackmcgill.atlassian.net/browse/HCK-185)
![image](https://user-images.githubusercontent.com/17463268/70962672-f3084000-2053-11ea-8108-ce6ee210f890.png)

### List of changes:

Added check to `updateAccount` middleware to see whether or not the new email already exists in the database, and if so, return a dup email error. 

Error should now be: "Email already in use"
![image](https://user-images.githubusercontent.com/17463268/70962753-34005480-2054-11ea-8a56-672d6a064501.png)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How has this been tested?

Ran test suite

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in downstream modules
