### PR TITLE
feat: add school and status to team members list

### DIFF
--- a/controllers/team.controller.js
+++ b/controllers/team.controller.js
@@ -21,23 +21,11 @@ const Constants = {
 function showTeam(req, res) {
     const teamData = req.body.team.toJSON();
 
-    const memberNames = [];
-    for (const member of req.body.teamMembers) {
-        const strippedMemberJSON = member.toStrippedJSON();
-
-        const memberName = {
-            firstName: strippedMemberJSON.firstName,
-            lastName: strippedMemberJSON.lastName
-        };
-
-        memberNames.push(memberName);
-    }
-
     return res.status(200).json({
         message: Constants.Success.TEAM_READ,
         data: {
             team: teamData,
-            members: memberNames
+            members: req.body.teamMembers
         }
     });
 }

--- a/middlewares/team.middleware.js
+++ b/middlewares/team.middleware.js
@@ -419,7 +419,12 @@ async function populateMemberAccountsById(req, res, next) {
     let teamMembers = [];
 
     for (const member of team.members) {
-        teamMembers.push(member.accountId);
+        teamMembers.push({
+            school: member.application.general.school,
+            status: member.status,
+            firstName: member.accountId.firstName,
+            lastName: member.accountId.lastName
+        });
         hackerIds.push(member._id);
     }
     team.members = hackerIds;

--- a/package.json
+++ b/package.json
@@ -3,11 +3,11 @@
     "version": "3.0.0",
     "private": true,
     "scripts": {
-        "start": "DEBUG=hackboard:* NODE_ENV=development nodemon --ignore gcp_creds.json ./bin/www.js",
+        "start": "DEBUG=hackboard:* NODE_ENV=test nodemon --ignore gcp_creds.json ./bin/www.js",
         "deploy": "NODE_ENV=deployment node ./bin/www.js",
-        "debug": "DEBUG=hackboard:* NODE_ENV=deployment nodemon --ignore gcp_creds.json ./bin/www.js",
+        "debug": "DEBUG=hackboard:* NODE_ENV=test nodemon --ignore gcp_creds.json ./bin/www.js",
         "test": "DEBUG=hackboard:* NODE_ENV=test mocha --reporter spec tests/**.js --exit",
-        "seed": "NODE_ENV=development node ./seed/index.js",
+        "seed": "NODE_ENV=test node ./seed/index.js",
         "docs": "apidoc -i ./routes -o ./docs/api/",
         "format": "prettier --write '**/*.js'",
         "lint": "eslint --fix '**/*.js'"

--- a/routes/api/team.js
+++ b/routes/api/team.js
@@ -21,7 +21,7 @@ const Services = {
 };
 
 module.exports = {
-    activate: function(apiRouter) {
+    activate: function (apiRouter) {
         const teamRouter = new express.Router();
 
         /**
@@ -137,7 +137,8 @@ module.exports = {
                         "members": [
                             {
                                 "firstName": "John",
-                                "lastName": "Doe"
+                                "lastName": "Doe",
+                                "school": "McGill University"
                             }
                         ],
                     }

--- a/routes/api/team.js
+++ b/routes/api/team.js
@@ -138,7 +138,8 @@ module.exports = {
                             {
                                 "firstName": "John",
                                 "lastName": "Doe",
-                                "school": "McGill University"
+                                "school": "McGill University",
+                                "status": "Applied"
                             }
                         ],
                     }

--- a/tests/team.test.js
+++ b/tests/team.test.js
@@ -25,11 +25,11 @@ const teamHackerAccount0 = util.account.hackerAccounts.stored.team[0];
 const noTeamHackerAccount0 = util.account.hackerAccounts.stored.noTeam[0];
 const sponsorT1Account0 = util.account.sponsorT1Accounts.stored[0];
 
-describe("GET team", function() {
-    it("should FAIL to list a team's information due to lack of authentication", function(done) {
+describe("GET team", function () {
+    it("should FAIL to list a team's information due to lack of authentication", function (done) {
         chai.request(server.app)
             .get(`/api/team/${util.team.Team3._id}`)
-            .end(function(err, res) {
+            .end(function (err, res) {
                 res.should.have.status(401);
                 res.should.be.json;
                 res.body.should.have.property("message");
@@ -40,7 +40,7 @@ describe("GET team", function() {
             });
     });
 
-    it("should Fail and list a team's information from /api/team/ GET due to non existant team id", function(done) {
+    it("should Fail and list a team's information from /api/team/ GET due to non existant team id", function (done) {
         util.auth.login(
             agent,
             util.account.hackerAccounts.stored.team[0],
@@ -51,7 +51,7 @@ describe("GET team", function() {
                 }
                 return agent
                     .get(`/api/team/${util.team.newTeam1._id}`)
-                    .end(function(err, res) {
+                    .end(function (err, res) {
                         res.should.have.status(404);
                         res.should.be.json;
                         res.body.should.have.property("message");
@@ -66,7 +66,7 @@ describe("GET team", function() {
         );
     });
 
-    it("should SUCCEED and list a team's information from /api/team/ GET", function(done) {
+    it("should SUCCEED and list a team's information from /api/team/ GET", function (done) {
         util.auth.login(agent, util.account.waitlistedHacker0, (error) => {
             if (error) {
                 agent.close();
@@ -74,7 +74,7 @@ describe("GET team", function() {
             }
             return agent
                 .get(`/api/team/${util.team.Team3._id}`)
-                .end(function(err, res) {
+                .end(function (err, res) {
                     res.should.have.status(200);
                     res.should.be.json;
                     res.body.should.have.property("message");
@@ -103,11 +103,23 @@ describe("GET team", function() {
                     res.body.data.members[0].lastName.should.equal(
                         util.account.hackerAccounts.stored.team[1].lastName
                     );
+                    res.body.data.members[0].status.should.equal(
+                        util.hacker.TeamHacker1.status
+                    );
+                    res.body.data.members[0].school.should.equal(
+                        util.hacker.TeamHacker1.application.general.school
+                    );
                     res.body.data.members[1].firstName.should.equal(
                         util.account.hackerAccounts.stored.team[2].firstName
                     );
                     res.body.data.members[1].lastName.should.equal(
                         util.account.hackerAccounts.stored.team[2].lastName
+                    );
+                    res.body.data.members[1].status.should.equal(
+                        util.hacker.TeamHacker2.status
+                    );
+                    res.body.data.members[1].school.should.equal(
+                        util.hacker.TeamHacker2.application.general.school
                     );
                     res.body.data.members[2].firstName.should.equal(
                         util.account.hackerAccounts.stored.team[3].firstName
@@ -115,11 +127,23 @@ describe("GET team", function() {
                     res.body.data.members[2].lastName.should.equal(
                         util.account.hackerAccounts.stored.team[3].lastName
                     );
+                    res.body.data.members[2].status.should.equal(
+                        util.hacker.TeamHacker3.status
+                    );
+                    res.body.data.members[2].school.should.equal(
+                        util.hacker.TeamHacker3.application.general.school
+                    );
                     res.body.data.members[3].firstName.should.equal(
                         util.account.hackerAccounts.stored.team[4].firstName
                     );
                     res.body.data.members[3].lastName.should.equal(
                         util.account.hackerAccounts.stored.team[4].lastName
+                    );
+                    res.body.data.members[4].status.should.equal(
+                        util.hacker.TeamHacker4.status
+                    );
+                    res.body.data.members[4].school.should.equal(
+                        util.hacker.TeamHacker4.application.general.school
                     );
 
                     done();
@@ -128,13 +152,13 @@ describe("GET team", function() {
     });
 });
 
-describe("POST create team", function() {
-    it("should FAIL to create a new team due to lack of authentication", function(done) {
+describe("POST create team", function () {
+    it("should FAIL to create a new team due to lack of authentication", function (done) {
         chai.request(server.app)
             .post(`/api/team/`)
             .type("application/json")
             .send(util.team.newTeam1)
-            .end(function(err, res) {
+            .end(function (err, res) {
                 res.should.have.status(401);
                 res.should.be.json;
                 res.body.should.have.property("message");
@@ -145,7 +169,7 @@ describe("POST create team", function() {
             });
     });
 
-    it("should FAIL to create a new team due to lack of authorization", function(done) {
+    it("should FAIL to create a new team due to lack of authorization", function (done) {
         util.auth.login(agent, sponsorT1Account0, (error) => {
             if (error) {
                 agent.close();
@@ -155,7 +179,7 @@ describe("POST create team", function() {
                 .post(`/api/team/`)
                 .type("application/json")
                 .send(util.team.newTeam1)
-                .end(function(err, res) {
+                .end(function (err, res) {
                     res.should.have.status(403);
                     res.should.be.json;
                     res.body.should.have.property("message");
@@ -169,7 +193,7 @@ describe("POST create team", function() {
         });
     });
 
-    it("should FAIL to create a new team due to logged in user not being a hacker", function(done) {
+    it("should FAIL to create a new team due to logged in user not being a hacker", function (done) {
         util.auth.login(agent, Admin0, (error) => {
             if (error) {
                 agent.close();
@@ -179,7 +203,7 @@ describe("POST create team", function() {
                 .post(`/api/team/`)
                 .type("application/json")
                 .send(util.team.newTeam1)
-                .end(function(err, res) {
+                .end(function (err, res) {
                     res.should.have.status(404);
                     res.should.be.json;
                     res.body.should.have.property("message");
@@ -193,7 +217,7 @@ describe("POST create team", function() {
         });
     });
 
-    it("should FAIL to create a new team due to duplicate team name", function(done) {
+    it("should FAIL to create a new team due to duplicate team name", function (done) {
         util.auth.login(agent, noTeamHackerAccount0, (error) => {
             if (error) {
                 agent.close();
@@ -203,7 +227,7 @@ describe("POST create team", function() {
                 .post(`/api/team/`)
                 .type("application/json")
                 .send(util.team.duplicateTeamName1)
-                .end(function(err, res) {
+                .end(function (err, res) {
                     res.should.have.status(409);
                     res.should.be.json;
                     res.body.should.have.property("message");
@@ -220,7 +244,7 @@ describe("POST create team", function() {
         });
     });
 
-    it("should Fail to create a new team due to hacker already being in a team", function(done) {
+    it("should Fail to create a new team due to hacker already being in a team", function (done) {
         util.auth.login(agent, teamHackerAccount0, (error) => {
             if (error) {
                 agent.close();
@@ -230,7 +254,7 @@ describe("POST create team", function() {
                 .post(`/api/team/`)
                 .type("application/json")
                 .send(util.team.newTeam1)
-                .end(function(err, res) {
+                .end(function (err, res) {
                     res.should.have.status(409);
                     res.should.be.json;
                     res.body.should.have.property("message");
@@ -243,7 +267,7 @@ describe("POST create team", function() {
         });
     });
 
-    it("should SUCCEED and create a new team", function(done) {
+    it("should SUCCEED and create a new team", function (done) {
         util.auth.login(agent, noTeamHackerAccount0, (error) => {
             if (error) {
                 agent.close();
@@ -253,7 +277,7 @@ describe("POST create team", function() {
                 .post(`/api/team/`)
                 .type("application/json")
                 .send(util.team.newTeam1)
-                .end(function(err, res) {
+                .end(function (err, res) {
                     res.should.have.status(200);
                     res.should.be.json;
                     res.body.should.have.property("message");
@@ -276,15 +300,15 @@ describe("POST create team", function() {
     });
 });
 
-describe("PATCH join team", function() {
-    it("should FAIL to join a hacker to a team due to lack of authentication", function(done) {
+describe("PATCH join team", function () {
+    it("should FAIL to join a hacker to a team due to lack of authentication", function (done) {
         chai.request(server.app)
             .patch(`/api/team/join/`)
             .type("application/json")
             .send({
                 name: "BronzeTeam"
             })
-            .end(function(err, res) {
+            .end(function (err, res) {
                 res.should.have.status(401);
                 res.should.be.json;
                 res.body.should.have.property("message");
@@ -295,7 +319,7 @@ describe("PATCH join team", function() {
             });
     });
 
-    it("should FAIL to join a volunteer to a team.", function(done) {
+    it("should FAIL to join a volunteer to a team.", function (done) {
         util.auth.login(
             agent,
             util.account.volunteerAccounts.stored[0],
@@ -310,7 +334,7 @@ describe("PATCH join team", function() {
                     .send({
                         name: "BronzeTeam"
                     })
-                    .end(function(err, res) {
+                    .end(function (err, res) {
                         res.should.have.status(403);
                         res.should.be.json;
                         res.body.should.have.property("message");
@@ -325,7 +349,7 @@ describe("PATCH join team", function() {
         );
     });
 
-    it("should FAIL to join a hacker to a team that doesn't exist.", function(done) {
+    it("should FAIL to join a hacker to a team that doesn't exist.", function (done) {
         util.auth.login(agent, teamHackerAccount0, (error) => {
             if (error) {
                 agent.close();
@@ -337,7 +361,7 @@ describe("PATCH join team", function() {
                 .send({
                     name: "NonExistTeam"
                 })
-                .end(function(err, res) {
+                .end(function (err, res) {
                     res.should.have.status(404);
                     res.should.be.json;
                     res.body.should.have.property("message");
@@ -351,7 +375,7 @@ describe("PATCH join team", function() {
         });
     });
 
-    it("should FAIL to join a hacker to a team that is full.", function(done) {
+    it("should FAIL to join a hacker to a team that is full.", function (done) {
         util.auth.login(agent, teamHackerAccount0, (error) => {
             if (error) {
                 agent.close();
@@ -363,7 +387,7 @@ describe("PATCH join team", function() {
                 .send({
                     name: "FullTeam"
                 })
-                .end(function(err, res) {
+                .end(function (err, res) {
                     res.should.have.status(409);
                     res.should.be.json;
                     res.body.should.have.property("message");
@@ -377,7 +401,7 @@ describe("PATCH join team", function() {
         });
     });
 
-    it("should SUCCEED and join a hacker without a team to a team.", function(done) {
+    it("should SUCCEED and join a hacker without a team to a team.", function (done) {
         util.auth.login(agent, noTeamHackerAccount0, (error) => {
             if (error) {
                 agent.close();
@@ -389,7 +413,7 @@ describe("PATCH join team", function() {
                 .send({
                     name: "BronzeTeam"
                 })
-                .end(function(err, res) {
+                .end(function (err, res) {
                     res.should.have.status(200);
                     res.should.be.json;
                     res.body.should.have.property("message");
@@ -401,7 +425,7 @@ describe("PATCH join team", function() {
         });
     });
 
-    it("should SUCCEED and join a hacker on a team to aother team.", function(done) {
+    it("should SUCCEED and join a hacker on a team to aother team.", function (done) {
         util.auth.login(agent, teamHackerAccount0, (error) => {
             if (error) {
                 agent.close();
@@ -413,7 +437,7 @@ describe("PATCH join team", function() {
                 .send({
                     name: "SilverTeam"
                 })
-                .end(function(err, res) {
+                .end(function (err, res) {
                     res.should.have.status(200);
                     res.should.be.json;
                     res.body.should.have.property("message");
@@ -426,15 +450,15 @@ describe("PATCH join team", function() {
     });
 });
 
-describe("PATCH change team info", function() {
-    it("should FAIL to change a hacker's team information due to invalid authentication", function(done) {
+describe("PATCH change team info", function () {
+    it("should FAIL to change a hacker's team information due to invalid authentication", function (done) {
         chai.request(server.app)
             .patch(`/api/team/${util.hacker.TeamHacker4._id}`)
             .type("application/json")
             .send({
                 name: "BronzeTeamASDF"
             })
-            .end(function(err, res) {
+            .end(function (err, res) {
                 res.should.have.status(401);
                 res.should.be.json;
                 res.body.should.have.property("message");
@@ -445,7 +469,7 @@ describe("PATCH change team info", function() {
             });
     });
 
-    it("should FAIL for a hacker to change another team's information due to invalid authorization", function(done) {
+    it("should FAIL for a hacker to change another team's information due to invalid authorization", function (done) {
         util.auth.login(
             agent,
             util.account.hackerAccounts.stored.team[1],
@@ -460,7 +484,7 @@ describe("PATCH change team info", function() {
                     .send({
                         name: "SuccessTeamASDF"
                     })
-                    .end(function(err, res) {
+                    .end(function (err, res) {
                         res.should.have.status(403);
                         res.should.be.json;
                         res.body.should.have.property("message");
@@ -475,7 +499,7 @@ describe("PATCH change team info", function() {
         );
     });
 
-    it("should SUCCEED to change the hacker's team information", function(done) {
+    it("should SUCCEED to change the hacker's team information", function (done) {
         util.auth.login(
             agent,
             util.account.hackerAccounts.stored.team[1],
@@ -490,7 +514,7 @@ describe("PATCH change team info", function() {
                     .send({
                         name: "SuccessTeamASDF"
                     })
-                    .end(function(err, res) {
+                    .end(function (err, res) {
                         res.should.have.status(200);
                         res.should.be.json;
                         res.body.should.have.property("message");
@@ -506,7 +530,7 @@ describe("PATCH change team info", function() {
         );
     });
 
-    it("should SUCCEED and leave a team.", function(done) {
+    it("should SUCCEED and leave a team.", function (done) {
         util.auth.login(agent, teamHackerAccount0, (error) => {
             if (error) {
                 agent.close();
@@ -515,7 +539,7 @@ describe("PATCH change team info", function() {
             return agent
                 .patch(`/api/team/leave/`)
                 .type("application/json")
-                .end(function(err, res) {
+                .end(function (err, res) {
                     res.should.have.status(200);
                     res.should.be.json;
                     res.body.should.have.property("message");
@@ -528,7 +552,7 @@ describe("PATCH change team info", function() {
         });
     });
 
-    it("should SUCCEED for an admin to change a team information", function(done) {
+    it("should SUCCEED for an admin to change a team information", function (done) {
         util.auth.login(agent, Admin0, (error) => {
             if (error) {
                 agent.close();
@@ -540,7 +564,7 @@ describe("PATCH change team info", function() {
                 .send({
                     name: "SuccessTeamASDF"
                 })
-                .end(function(err, res) {
+                .end(function (err, res) {
                     res.should.have.status(200);
                     res.should.be.json;
                     res.body.should.have.property("message");
@@ -556,11 +580,11 @@ describe("PATCH change team info", function() {
         });
     });
 
-    it("should FAIL to leave a team due to invalid authentication.", function(done) {
+    it("should FAIL to leave a team due to invalid authentication.", function (done) {
         chai.request(server.app)
             .patch(`/api/team/leave/`)
             .type("application/json")
-            .end(function(err, res) {
+            .end(function (err, res) {
                 res.should.have.status(401);
                 res.should.be.json;
                 res.body.should.have.property("message");

--- a/tests/team.test.js
+++ b/tests/team.test.js
@@ -139,10 +139,10 @@ describe("GET team", function () {
                     res.body.data.members[3].lastName.should.equal(
                         util.account.hackerAccounts.stored.team[4].lastName
                     );
-                    res.body.data.members[4].status.should.equal(
+                    res.body.data.members[3].status.should.equal(
                         util.hacker.TeamHacker4.status
                     );
-                    res.body.data.members[4].school.should.equal(
+                    res.body.data.members[3].school.should.equal(
                         util.hacker.TeamHacker4.application.general.school
                     );
 


### PR DESCRIPTION
### Tickets:

-   HCK- #684 

### List of changes:

- GET /team/:id now returns schools and status of team members in format:
```
 {
  "message": "Team retrieval successful", 
  "data": {        
    "team": {
      "name":"foo",
      "members": [
        ObjectId('...')
      ],
      "devpostURL": "www.devpost.com/foo",
      "projectName": "fooey"
    },
    "members": [
      {
        "firstName": "John",
        "lastName": "Doe",
        "school": "McGill University",
        "status": "Applied"
      }
    ],
  }
}
```

## Type of change

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] New release
-   [ ] This change requires a documentation update

### How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Modified  it("should SUCCEED and list a team's information from /api/team/ GET") test case so test confirmed correct status and school were also returned.

**Test Configuration**:

**Firmware version:**
**Hardware:**
**Toolchain:**
**SDK:**

### Questions for code reviewers?

### Checklist:

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings
-   [ ] Listed change(s) in the Changelog
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
-   [x] I have made corresponding changes to the documentation
-   [x] Any dependent changes have been merged and published in downstream modules
