### PR TITLE
fix： share github secrets to dependabot (#712)

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -8,6 +8,8 @@ on:
     branches: [ dev, master ]
   pull_request:
     branches: [ dev, master ]
+  pull_request_target:
+    branches: [ dev, master ]
 
 jobs:
   build:
@@ -24,8 +26,21 @@ jobs:
         node-version: [14.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
+    if: |
+      (github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]') ||
+      (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]')
+
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout
+      if: ${{ github.event_name != 'pull_request_target' }}
+      uses: actions/checkout@v2
+
+    - name: Checkout PR
+      if: ${{ github.event_name == 'pull_request_target' }}
+      uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+        
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v2
       with:


### PR DESCRIPTION
### Tickets:

-   N/A

### List of changes:

- merged in new workflow ([HAC-35](https://linear.app/hackmcgill/issue/HAC-35/dependabot-prs-cant-see-repo-secrets)) to share GitHub Secrets with Dependabot

## Type of change

-   [ ] Bug fix (non-breaking change which fixes an issue)

### How has this been tested?

-   [ ] GitHub Actions

### Questions for code reviewers?

### Checklist:

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings
-   [ ] Listed change(s) in the Changelog
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
-   [ ] I have made corresponding changes to the documentation
-   [ ] Any dependent changes have been merged and published in downstream modules
