### PR TITLE
Revert "build(deps): bump express-validator from 6.12.0 to 6.12.1 (#7…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2290,12 +2290,19 @@
       }
     },
     "express-validator": {
-      "version": "6.12.1",
-      "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-6.12.1.tgz",
-      "integrity": "sha512-olpTAv0ZB5IhNuDQ2rodKAuJsewgFgLIsczJMAWD6T0Yvxsa+j/Hk61jl8e26lAq+oJr6hUqPRjdlOBKhFlWeQ==",
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-6.12.0.tgz",
+      "integrity": "sha512-lcQAdVeAO+pBbHD33nIsDsd+QPakLX08tJ82iEsXj6ezyWCfYjE9RY/g9SVq5z4G0NaIkH8039Oe4r0G92DRyA==",
       "requires": {
         "lodash": "^4.17.21",
         "validator": "^13.5.2"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+        }
       }
     },
     "express-winston": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
         "debug": "~4.3.2",
         "dotenv": "^10.0.0",
         "express": "~4.17.1",
-        "express-validator": "^6.12.1",
+        "express-validator": "^6.12.0",
         "express-winston": "^2.6.0",
         "handlebars": "^4.7.7",
         "jsonwebtoken": "^8.5.1",


### PR DESCRIPTION

This reverts commit e19b4470ad420718dbe2304ac955eeea5f0b5756.

### Tickets:

-   HAC-
### List of changes:

Checks failed after commit

-

## Type of change

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] New release
-   [ ] This change requires a documentation update

### How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

-   [ ] Test A
-   [ ] Test B

**Test Configuration**:

**Firmware version:**
**Hardware:**
**Toolchain:**
**SDK:**

### Questions for code reviewers?

### Checklist:

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings
-   [ ] Listed change(s) in the Changelog
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
-   [ ] I have made corresponding changes to the documentation
-   [ ] Any dependent changes have been merged and published in downstream modules
