### PR TITLE
fix: team api fixes for creating and deleting a team

### DIFF
--- a/src/models/team.model.ts
+++ b/src/models/team.model.ts
@@ -26,13 +26,11 @@ class Team {
     @JoinColumn()
     members: Array<Hacker>;
 
-    @Column({ nullable: true })
-    @IsString()
-    submission?: string;
+    @Column({ type: String, nullable: true })
+    submission?: string | null;
 
-    @Column({ nullable: true })
-    @IsString()
-    project?: string;
+    @Column({ type: String, nullable: true })
+    project?: string | null;
 }
 
 export default Team;


### PR DESCRIPTION
## List of changes:
Removed the `@IsString()` annotation which forced it to be non-null. This broke the creation of a new team. Added a new piece of logic to `removeMember` which checks to see whether we just removed the last member of the team. If so, it deletes the team object as well. 

`Part of jacky/refactor (typescript refactor)`

## Type of change

Please delete options that are not relevant.

-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] New release
-   [ ] This change requires a documentation update

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my own code
-   [X] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings _(Added comments for this)_
-   [ ] Listed change(s) in the Changelog
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
-   [ ] I have made corresponding changes to the documentation
-   [ ] Any dependent changes have been merged and published in downstream modules
